### PR TITLE
Fix join() on key mixing Array and NullableArray

### DIFF
--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -131,26 +131,27 @@ sharepools{S,N}(v1::AbstractArray{S,N},
     sharepools(oftype(v2, v1), v2)
 
 # TODO: write an optimized version for (Nullable)CategoricalArray
-function sharepools(v1::AbstractArray,
-                    v2::AbstractArray)
+function sharepools{S, T}(v1::AbstractArray{S},
+                          v2::AbstractArray{T})
     ## Return two categorical arrays that share the same pool.
 
     ## TODO: allow specification of R
     R = CategoricalArrays.DefaultRefType
     refs1 = Array(R, size(v1))
     refs2 = Array(R, size(v2))
-    poolref = Dict{promote_type(eltype(v1), eltype(v2)), R}()
+    K = promote_type(S, T)
+    poolref = Dict{K, R}()
     maxref = 0
 
     # loop through once to fill the poolref dict
     for i = 1:length(v1)
         if !_isnull(v1[i])
-            poolref[v1[i]] = 0
+            poolref[K(v1[i])] = 0
         end
     end
     for i = 1:length(v2)
         if !_isnull(v2[i])
-            poolref[v2[i]] = 0
+            poolref[K(v2[i])] = 0
         end
     end
 
@@ -168,14 +169,14 @@ function sharepools(v1::AbstractArray,
         if _isnull(v1[i])
             refs1[i] = zeroval
         else
-            refs1[i] = poolref[v1[i]]
+            refs1[i] = poolref[K(v1[i])]
         end
     end
     for i = 1:length(v2)
         if _isnull(v2[i])
             refs2[i] = zeroval
         else
-            refs2[i] = poolref[v2[i]]
+            refs2[i] = poolref[K(v2[i])]
         end
     end
 

--- a/test/join.jl
+++ b/test/join.jl
@@ -107,4 +107,12 @@ module TestJoin
     @test join(df2, df, on=:Name, kind=:left) == DataTable(Name = ["A", "A", "B", "C"],
                                                            Quantity = [3, 4, 3, 2],
                                                            Mass = [1.5, 1.5, 2.2, 1.1])
+
+    # Test that join works when mixing Array and NullableArray (#1151)
+    df = DataTable([collect(1:10), collect(2:11)], [:x, :y])
+    dfnull = DataTable(x = 1:10, z = 3:12)
+    @test join(df, dfnull, on = :x) ==
+        DataTable([collect(1:10), collect(2:11), NullableArray(3:12)], [:x, :y, :z])
+    @test join(dfnull, df, on = :x) ==
+        DataTable([NullableArray(1:10), NullableArray(3:12), NullableArray(2:11)], [:x, :z, :y])
 end


### PR DESCRIPTION
Previously failed when trying to index Dict{T} with Nullable{T} key,
since isequal(::T, Nullable{T}) returns false even if convert() works.

Port of https://github.com/JuliaStats/DataFrames.jl/pull/1152.