### PR TITLE
WIP: Fix type instability in groupby()

### DIFF
--- a/src/groupeddatatable/grouping.jl
+++ b/src/groupeddatatable/grouping.jl
@@ -62,13 +62,13 @@ end
 
 function fill_groups!(x::AbstractVector, v::AbstractVector, ngroups::Integer)
     nv = NullableCategoricalArray(v)
-    anynulls = (findfirst(nv.refs, 0) > 0 ? 1 : 0)
+    anynulls = findfirst(nv.refs, 0) > 0
+    order = CategoricalArrays.order(nv.pool)
+    anynulls && unshift!(0, order)
     @inbounds for i in eachindex(x, v)
-        if nv.refs[i] != 0
-            x[i] += (CategoricalArrays.order(nv.pool)[nv.refs[i]] + anynulls - 1) * ngroups
-        end
+        x[i] += (order[nv.refs[i]] + anynulls - 1) * ngroups
     end
-    length(levels(nv)) + anynulls
+    length(order)
 end
 
 """

--- a/src/groupeddatatable/grouping.jl
+++ b/src/groupeddatatable/grouping.jl
@@ -31,9 +31,8 @@ function groupsort_indexer(x::AbstractVector, ngroups::Integer, null_last::Bool=
 
     # count group sizes, location 0 for NULL
     n = length(x)
-    # counts = x.pool
     counts = fill(0, ngroups + 1)
-    for i = 1:n
+    @inbounds for i in 1:n
         counts[x[i] + 1] += 1
     end
 
@@ -52,7 +51,7 @@ function groupsort_indexer(x::AbstractVector, ngroups::Integer, null_last::Bool=
 
     # this is our indexer
     result = fill(0, n)
-    for i = 1:n
+    @inbounds for i in 1:n
         label = x[i] + 1
         result[where[label]] = i
         where[label] += 1
@@ -150,8 +149,10 @@ function groupby{T}(d::AbstractDataTable, cols::Vector{T})
     (idx, starts) = groupsort_indexer(x, ngroups)
     # Remove zero-length groupings
     starts = _uniqueofsorted(starts)
-    ends = starts[2:end] - 1
-    GroupedDataTable(d, cols, idx, starts[1:end-1], ends)
+    ends = starts[2:end]
+    ends .-= 1
+    pop!(starts)
+    GroupedDataTable(d, cols, idx, starts, ends)
 end
 groupby(d::AbstractDataTable, cols) = groupby(d, [cols])
 


### PR DESCRIPTION
This ensures the loop over rows is type stable, which increases performance
a lot.

This is WIP because it must be balanced with https://github.com/JuliaData/DataTables.jl/pull/3. It's mainly intended to allow for performance comparisons.

The same strategy could be applied to DataFrames, which are faster than DataTables currently, but much slower than with this PR.

```julia
using DataTables
using BenchmarkTools

dt1 = DataFrame(v1 = PooledDataArray(repeat(1:10, inner=1000)), v2 = PooledDataArray(repeat(1:10, outer=1000)));
dt2 = DataFrame(v1 = PooledDataArray(repeat(1:100, inner=100)), v2 = PooledDataArray(repeat(1:100, outer=100)));
dt3 = hcat(dt1, dt2)

@benchmark groupby(dt1, [:v1, :v2])
@benchmark groupby(dt2, [:v1, :v2])
@benchmark groupby(dt3, [:v1, :v2, :v1_1, :v2_1])


# BEFORE
julia> @benchmark groupby(dt1, [:v1, :v2])

BenchmarkTools.Trial: 
  memory estimate:  1.22 MiB
  allocs estimate:  66536
  --------------
  minimum time:     4.527 ms (0.00% GC)
  median time:      4.747 ms (0.00% GC)
  mean time:        5.047 ms (2.08% GC)
  maximum time:     12.827 ms (18.36% GC)
  --------------
  samples:          988
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark groupby(dt2, [:v1, :v2])
BenchmarkTools.Trial: 
  memory estimate:  1.99 MiB
  allocs estimate:  85972
  --------------
  minimum time:     5.063 ms (0.00% GC)
  median time:      5.518 ms (0.00% GC)
  mean time:        6.066 ms (3.17% GC)
  maximum time:     13.451 ms (23.09% GC)
  --------------
  samples:          821
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark groupby(dt3, [:v1, :v2, :v1_1, :v2_1])
BenchmarkTools.Trial: 
  memory estimate:  20.45 MiB
  allocs estimate:  238751
  --------------
  minimum time:     17.675 ms (0.00% GC)
  median time:      20.564 ms (7.95% GC)
  mean time:        20.652 ms (7.97% GC)
  maximum time:     25.163 ms (6.69% GC)
  --------------
  samples:          242
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

# AFTER:
julia> @benchmark groupby(dt1, [:v1, :v2])
BenchmarkTools.Trial: 
  memory estimate:  122.64 KiB
  allocs estimate:  21
  --------------
  minimum time:     63.710 μs (0.00% GC)
  median time:      69.333 μs (0.00% GC)
  mean time:        76.896 μs (5.47% GC)
  maximum time:     971.994 μs (91.85% GC)
  --------------
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark groupby(dt2, [:v1, :v2])
BenchmarkTools.Trial: 
  memory estimate:  520.89 KiB
  allocs estimate:  29
  --------------
  minimum time:     148.724 μs (0.00% GC)
  median time:      163.476 μs (0.00% GC)
  mean time:        188.497 μs (8.29% GC)
  maximum time:     1.161 ms (74.62% GC)
  --------------
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%

julia> @benchmark groupby(dt3, [:v1, :v2, :v1_1, :v2_1])
BenchmarkTools.Trial: 
  memory estimate:  16.56 MiB
  allocs estimate:  36
  --------------
  minimum time:     7.442 ms (0.00% GC)
  median time:      8.863 ms (5.16% GC)
  mean time:        8.971 ms (7.86% GC)
  maximum time:     13.647 ms (22.29% GC)
  --------------
  samples:          556
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
```