### PR TITLE
Remove Juno code

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,4 +7,3 @@ SortingAlgorithms
 Reexport
 Compat 0.19.0
 FileIO 0.1.2
-Juno 0.2.4

--- a/src/abstractdatatable/show.jl
+++ b/src/abstractdatatable/show.jl
@@ -572,28 +572,3 @@ function showcols(io::IO, dt::AbstractDataTable) # -> Void
 end
 
 showcols(dt::AbstractDataTable) = showcols(STDOUT, dt) # -> Void
-
-using Juno
-using Juno: Inline, LazyTree, Table, Row, strong
-
-const SIZE = 25
-
-function to_matrix(dt::AbstractDataTable)
-    res = Array{Any}(size(dt))
-    for (j, col) in enumerate(columns(dt)), i = 1:length(col)
-        isassigned(col, i) && (res[i, j] = col[i])
-    end
-    return res
-end
-
-function _render(dt::AbstractDataTable)
-    width = min(size(dt, 2), SIZE)
-    height = min(size(dt, 1), SIZE)
-    header = map(x->strong(string(x)), reshape(names(dt), 1, width))
-    body = Juno.undefs(to_matrix(dt))[1:height, 1:width]
-    view = Table(vcat(header, body))
-    LazyTree(Row(typeof(dt), text" ", Juno.dims(size(dt)...)),
-             () -> [view])
-end
-
-@render Inline dt::AbstractDataTable _render(dt)

--- a/test/show.jl
+++ b/test/show.jl
@@ -17,14 +17,6 @@ module TestShow
     showall(io, subdt)
     showall(io, subdt, true)
 
-    if VERSION > v"0.5-"
-        using Juno
-        out = DataTables._render(dt)
-        @assert out.head.xs[1] == DataTable
-        @assert isa(out.children()[1], Juno.Table)
-        @assert size(out.children()[1].xs) == (4, 2)
-    end
-
     dtvec = DataTable[dt for _=1:3]
     show(io, dtvec)
     showall(io, dtvec)


### PR DESCRIPTION
Mirrors change in DataFrames, and fixes completely broken REPL on Julia 0.6.