### PR TITLE
Fix/remove references to JuliaStats

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,7 +39,7 @@ makedocs(
 
 deploydocs(
     # options
-    repo = "github.com/JuliaStats/DataTables.jl.git",
+    repo = "github.com/JuliaData/DataTables.jl.git",
     target = "build",
     deps = nothing,
     make = nothing,

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -145,5 +145,4 @@ In the next section, we'll discuss generic I/O strategy for reading and writing 
 
 While the `DataTables` package provides basic data manipulation capabilities, users are encouraged to use the following packages for more powerful and complete data querying functionality in the spirit of [dplyr](https://github.com/hadley/dplyr) and [LINQ](https://msdn.microsoft.com/en-us/library/bb397926.aspx):
 
-- [DataTablesMeta.jl](https://github.com/JuliaStats/DataTablesMeta.jl) provides metaprogramming tools for `DataTables` and associative objects. These macros improve performance and provide more convenient syntax.
 - [Query.jl](https://github.com/davidanthoff/Query.jl) provides a LINQ like interface to a large number of data sources, including `DataTable` instances.

--- a/src/groupeddatatable/grouping.jl
+++ b/src/groupeddatatable/grouping.jl
@@ -93,10 +93,6 @@ See the following for additional split-apply-combine operations:
 
 Piping methods `|>` are also provided.
 
-See the
-[DataTablesMeta](https://github.com/JuliaStats/DataTablesMeta.jl)
-package for more operations on GroupedDataTables.
-
 ### Examples
 
 ```julia


### PR DESCRIPTION
These either should have been changed to JuliaData, or the mentions should
have been removed completely. DataFramesMeta in particular does not currently
support DataTables, though we might update it at some point.

This should fix uploading the online manual.