### PR TITLE
replace `printtable` test

### DIFF
--- a/src/abstractdatatable/io.jl
+++ b/src/abstractdatatable/io.jl
@@ -42,7 +42,7 @@ function printtable(io::IO,
     quotestr = string(quotemark)
     for i in 1:n
         for j in 1:p
-            if !isnull(dt[j],i)
+            if !isnull(dt[j][i])
                 if ! (etypes[j] <: Real)
 		    print(io, quotemark)
 		    escapedprint(io, get(dt[i, j]), quotestr)

--- a/test/io.jl
+++ b/test/io.jl
@@ -48,5 +48,7 @@ module TestIO
                    F = NullableArray(fill(Nullable(), 26)),
                    G = fill(Nullable(), 26))
 
-    @test hash(sprint(printtable, dt)) == 0xfa1c667155d1f19c
+
+    answer = !is_windows() ? 0x4c515a9379629be9 : 0xdb9781f446a9a1f4
+    @test hash(sprint(printtable, dt), UInt64(0))) == answer
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -47,6 +47,6 @@ module TestIO
                    E = NullableArray(rand(26)),
                    F = NullableArray(fill(Nullable(), 26)),
                    G = fill(Nullable(), 26))
-    printtable(dt)
 
+    @test hash(sprint(printtable, dt)) == 0xfa1c667155d1f19c
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -48,6 +48,6 @@ module TestIO
                    F = NullableArray(fill(Nullable(), 26)),
                    G = fill(Nullable(), 26))
 
-    answer = !is_windows() ? 0xde54e70f51205910 : 0xdb9781f446a9a1f4
-    @test hash(sprint(printtable, dt), UInt64(0)) == answer
+    answer = Sys.WORD_SIZE == 64 ? 0xde54e70f51205910 : 0x340524cd
+    @test hash(sprint(printtable, dt)) == answer
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -2,6 +2,8 @@ module TestIO
     using Base.Test
     using DataTables
     using LaTeXStrings
+    using NullableArrays
+    using CategoricalArrays
 
     # Test LaTeX export
     dt = DataTable(A = 1:4,
@@ -37,5 +39,14 @@ module TestIO
     io = IOBuffer()
     show(io, "text/html", dt)
     @test length(String(take!(io))) < 10000
+
+    dt = DataTable(A = 1:26,
+                   B = 'a':'z',
+                   C = [string(x) for x='A':'Z'],
+                   D = CategoricalArray([string(x) for x='A':'Z']),
+                   E = NullableArray(rand(26)),
+                   F = NullableArray(fill(Nullable(), 26)),
+                   G = fill(Nullable(), 26))
+    printtable(dt)
 
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -48,7 +48,6 @@ module TestIO
                    F = NullableArray(fill(Nullable(), 26)),
                    G = fill(Nullable(), 26))
 
-
-    answer = !is_windows() ? 0x4c515a9379629be9 : 0xdb9781f446a9a1f4
-    @test hash(sprint(printtable, dt), UInt64(0))) == answer
+    answer = !is_windows() ? 0xde54e70f51205910 : 0xdb9781f446a9a1f4
+    @test hash(sprint(printtable, dt), UInt64(0)) == answer
 end


### PR DESCRIPTION
The old, now removed tests depended on dataset files we removed and was actually part of the benchmark tests. This test does the same in that it has to successfully run to pass tests, but it still doesn't check the output (same as the old tests). Is it possible to test the printed values?