### PR TITLE
Update subdatatable.jl

### DIFF
--- a/src/subdatatable/subdatatable.jl
+++ b/src/subdatatable/subdatatable.jl
@@ -115,7 +115,7 @@ function Base.view(sdt::SubDataTable, rowinds::AbstractVector{Bool})
 end
 
 function Base.view(adt::AbstractDataTable, rowinds::Integer)
-    return SubDataTable(adt, Int[rowinds])
+    return view(adt, Int[rowinds])
 end
 
 function Base.view(adt::AbstractDataTable, rowinds::Any)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -48,5 +48,6 @@ module TestConstructors
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
     @test isequal(SubDataTable(DataTable(A=1), 1), DataTable(A=1))
     @test isequal(SubDataTable(DataTable(A=1:10), 1:4), DataTable(A=1:4))
+    @test isequal(view(SubDataTable(DataTable(A=1:10), 1:4), 2), DataTable(A=2))
     @test isequal(view(SubDataTable(DataTable(A=1:10), 1:4), [true, true, false, false]), DataTable(A=1:2))
 end


### PR DESCRIPTION
Fixes issue when trying to `view(::SubDataTable, ::Int)`. I think so at least. I edited this patch on github

```julia
julia> dt = DataTable(x1 = rand(4), x2 = rand(4))
4×2 DataTables.DataTable
│ Row │ x1       │ x2       │
├─────┼──────────┼──────────┤
│ 1   │ 0.163479 │ 0.469325 │
│ 2   │ 0.821491 │ 0.939964 │
│ 3   │ 0.121741 │ 0.985533 │
│ 4   │ 0.613799 │ 0.194209 │

julia> v = view(dt, 1) #works
1×2 DataTables.SubDataTable{Array{Int64,1}}
│ Row │ x1       │ x2       │
├─────┼──────────┼──────────┤
│ 1   │ 0.163479 │ 0.469325 │

julia> v = view(dt, 1:2)
2×2 DataTables.SubDataTable{UnitRange{Int64}}
│ Row │ x1       │ x2       │
├─────┼──────────┼──────────┤
│ 1   │ 0.163479 │ 0.469325 │
│ 2   │ 0.821491 │ 0.939964 │

julia> view(v, 1)
ERROR: MethodError: no method matching DataTables.SubDataTable{T<:AbstractArray{Int64,1}}(::DataTables.SubDataTable{UnitRange{Int64}}, ::Array{Int64,1})
```