### PR TITLE
Fix typo in example (as in DataFrames)

### DIFF
--- a/docs/src/man/joins.md
+++ b/docs/src/man/joins.md
@@ -3,8 +3,8 @@
 We often need to combine two or more data sets together to provide a complete picture of the topic we are studying. For example, suppose that we have the following two data sets:
 
 ```julia
-names = DataTable(ID = [1, 2], Name = ["John Doe", "Jane Doe"])
-jobs = DataTable(ID = [1, 2], Job = ["Lawyer", "Doctor"])
+names = DataTable(ID = [20, 40], Name = ["John Doe", "Jane Doe"])
+jobs = DataTable(ID = [20, 40], Job = ["Lawyer", "Doctor"])
 ```
 
 We might want to work with a larger data set that contains both the names and jobs for each ID. We can do this using the `join` function:
@@ -17,8 +17,8 @@ Output:
 
 | Row | ID | Name       | Job      |
 |-----|----|------------|----------|
-| 1   | 1  | "John Doe" | "Lawyer" |
-| 2   | 1  | "Jane Doe" | "Doctor" |
+| 1   | 20 | "John Doe" | "Lawyer" |
+| 2   | 40 | "Jane Doe" | "Doctor" |
 
 In relational database theory, this operation is generally referred to as a join. The columns used to determine which rows should be combined during a join are called keys.
 
@@ -35,8 +35,8 @@ There are seven kinds of joins supported by the DataTables package:
 You can control the kind of join that `join` performs using the `kind` keyword argument:
 
 ```julia
-a = DataTable(ID = [1, 2], Name = ["A", "B"])
-b = DataTable(ID = [1, 3], Job = ["Doctor", "Lawyer"])
+a = DataTable(ID = [20, 40], Name = ["John Doe", "Jane Doe"])
+b = DataTable(ID = [20, 60], Job = ["Lawyer", "Astronaut"])
 join(a, b, on = :ID, kind = :inner)
 join(a, b, on = :ID, kind = :left)
 join(a, b, on = :ID, kind = :right)
@@ -54,8 +54,8 @@ join(a, b, kind = :cross)
 In order to join data tables on keys which have different names, you must first rename them so that they match. This can be done using rename!:
 
 ```julia
-a = DataTable(ID = [1, 2], Name = ["A", "B"])
-b = DataTable(IDNew = [1, 2], Job = ["Doctor", "Lawyer"])
+a = DataTable(ID = [20, 40], Name = ["John Doe", "Jane Doe"])
+b = DataTable(IDNew = [20, 40], Job = ["Lawyer", "Doctor"])
 rename!(b, :IDNew, :ID)
 join(a, b, on = :ID, kind = :inner)
 ```


### PR DESCRIPTION
ID in example output was duplicated. Make ID distinct from row number, to avoid confusion. Align examples. Parallel to https://github.com/JuliaStats/DataFrames.jl/pull/1179