### PR TITLE
Update CSV examples to reflect that DataFrames is default CSV sink

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -159,14 +159,19 @@ using CSV
 using DataTables, CSV
 ```
 
-Datasets can now be read using
+A dataset can now be read from a CSV file at path `input` using
 ```julia
-CSV.read(...)
+CSV.read(input, DataTable)
 ```
 
-and written using
+Note the second positional argument of `DataTable`. This instructs the CSV package to output
+a `DataTable` rather than the default `DataFrame`. Keyword arguments may be passed to
+`CSV.read` after this second argument.
+
+A DataTable can be written to a CSV file at path `output` using
 ```julia
-CSV.write(...)
+dt = DataTable(x = 1, y = 2)
+CSV.write(output, dt)
 ```
 
 For more information, use the REPL [help-mode](http://docs.julialang.org/en/stable/manual/interacting-with-julia/#help-mode) or checkout the online [CSV.jl documentation](https://juliadata.github.io/CSV.jl/stable/)!
@@ -179,7 +184,7 @@ For example, we can access Fisher's iris data set using the following functions:
 
 ```julia
 using CSV
-iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"))
+iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"), DataTable)
 head(iris)
 ```
 

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -5,7 +5,7 @@ Reshape data from wide to long format using the `stack` function:
 ```julia
 using DataTables
 using CSV
-iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"))
+iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"), DataTable)
 iris[:id] = 1:size(iris, 1)  # this makes it easier to unstack
 d = stack(iris, 1:4)
 ```

--- a/docs/src/man/sorting.md
+++ b/docs/src/man/sorting.md
@@ -4,7 +4,8 @@ Sorting is a fundamental component of data analysis. Basic sorting is trivial: j
 
 ```julia
 using DataTables
-iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"))
+using CSV
+iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"), DataTable)
 sort!(iris)
 ```
 

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -8,7 +8,8 @@ We show several examples of the `by` function applied to the `iris` dataset belo
 
 ```julia
 using DataTables
-iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"))
+using CSV
+iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"), DataTable)
 
 by(iris, :Species, size)
 by(iris, :Species, dt -> mean(dropnull(dt[:PetalLength])))


### PR DESCRIPTION
Current examples assume DataTable is the default sink. https://github.com/JuliaData/CSV.jl/issues/73