### PR TITLE
Consolidate DataTable constructors and remove autopromotion

### DIFF
--- a/test/cat.jl
+++ b/test/cat.jl
@@ -113,8 +113,8 @@ module TestCat
     end
 
     # Minimal container type promotion
-    dta = DataTable(a = CategoricalArray([1, 2, 2]))
-    dtb = DataTable(a = CategoricalArray([2, 3, 4]))
+    dta = DataTable(a = NullableCategoricalArray([1, 2, 2]))
+    dtb = DataTable(a = NullableCategoricalArray([2, 3, 4]))
     dtc = DataTable(a = NullableArray([2, 3, 4]))
     dtd = DataTable(Any[2:4], [:a])
     dtab = vcat(dta, dtb)
@@ -122,13 +122,7 @@ module TestCat
     @test isequal(dtab[:a], Nullable{Int}[1, 2, 2, 2, 3, 4])
     @test isequal(dtac[:a], Nullable{Int}[1, 2, 2, 2, 3, 4])
     @test isa(dtab[:a], NullableCategoricalVector{Int})
-    # Fails on Julia 0.4 since promote_type(Nullable{Int}, Nullable{Float64}) gives Nullable{T}
-    if VERSION >= v"0.5.0-dev"
-        @test isa(dtac[:a], NullableCategoricalVector{Int})
-    else
-        @test isa(dtac[:a], NullableCategoricalVector{Any})
-    end
-    # ^^ container may flip if container promotion happens in Base/DataArrays
+    @test isa(dtac[:a], NullableCategoricalVector{Int})
     dc = vcat(dtd, dtc)
     @test isequal(vcat(dtc, dtd), dc)
 
@@ -147,5 +141,7 @@ module TestCat
     @test isequal(vcat(dtda, dtd, dta), vcat(dtda, dtda))
 
     # vcat should be able to concatenate different implementations of AbstractDataTable (PR #944)
-    @test isequal(vcat(view(DataTable(A=1:3),2),DataTable(A=4:5)), DataTable(A=[2,4,5]))
+    x = view(DataTable(A = NullableArray(1:3)), 2)
+    y = DataTable(A = NullableArray(4:5))
+    @test isequal(vcat(x, y), DataTable(A = NullableArray([2, 4, 5])))
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -18,31 +18,31 @@ module TestConstructors
 
     @test isequal(dt, DataTable(Any[NullableCategoricalVector(zeros(3)),
                                     NullableCategoricalVector(ones(3))]))
-    @test isequal(dt, DataTable(x1 = [0.0, 0.0, 0.0],
-                                x2 = [1.0, 1.0, 1.0]))
+    @test isequal(dt, DataTable(x1 = NullableArray([0.0, 0.0, 0.0]),
+                                x2 = NullableArray([1.0, 1.0, 1.0])))
 
-    dt2 = convert(DataTable, [0.0 1.0;
-                              0.0 1.0;
-                              0.0 1.0])
+    dt2 = convert(DataTable, NullableArray([0.0 1.0;
+                                            0.0 1.0;
+                                            0.0 1.0]))
     names!(dt2, [:x1, :x2])
     @test isequal(dt[:x1], NullableArray(dt2[:x1]))
     @test isequal(dt[:x2], NullableArray(dt2[:x2]))
 
-    @test isequal(dt, DataTable(x1 = [0.0, 0.0, 0.0],
-                                x2 = [1.0, 1.0, 1.0]))
-    @test isequal(dt, DataTable(x1 = [0.0, 0.0, 0.0],
-                                x2 = [1.0, 1.0, 1.0],
-                                x3 = [2.0, 2.0, 2.0])[[:x1, :x2]])
+    @test isequal(dt, DataTable(x1 = NullableArray([0.0, 0.0, 0.0]),
+                                x2 = NullableArray([1.0, 1.0, 1.0])))
+    @test isequal(dt, DataTable(x1 = NullableArray([0.0, 0.0, 0.0]),
+                                x2 = NullableArray([1.0, 1.0, 1.0]),
+                                x3 = NullableArray([2.0, 2.0, 2.0]))[[:x1, :x2]])
 
-    dt = DataTable(Int, 2, 2)
+    dt = DataTable(Nullable{Int}, 2, 2)
     @test size(dt) == (2, 2)
     @test eltypes(dt) == [Nullable{Int}, Nullable{Int}]
 
-    dt = DataTable([Int, Float64], [:x1, :x2], 2)
+    dt = DataTable([Nullable{Int}, Nullable{Float64}], [:x1, :x2], 2)
     @test size(dt) == (2, 2)
     @test eltypes(dt) == [Nullable{Int}, Nullable{Float64}]
 
-    @test isequal(dt, DataTable([Int, Float64], 2))
+    @test isequal(dt, DataTable([Nullable{Int}, Nullable{Float64}], 2))
 
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
@@ -50,4 +50,36 @@ module TestConstructors
     @test isequal(SubDataTable(DataTable(A=1:10), 1:4), DataTable(A=1:4))
     @test isequal(view(SubDataTable(DataTable(A=1:10), 1:4), 2), DataTable(A=2))
     @test isequal(view(SubDataTable(DataTable(A=1:10), 1:4), [true, true, false, false]), DataTable(A=1:2))
+
+    @test DataTable(a=1, b=1:2) == DataTable(a=[1,1], b=[1,2])
+
+    @testset "associative" begin
+        dt = DataTable(Dict(:A => 1:3, :B => 4:6))
+        @test dt == DataTable(A = 1:3, B = 4:6)
+        @test all(e -> e <: Int, eltypes(dt))
+    end
+
+    @testset "recyclers" begin
+        @test DataTable(a = 1:5, b = 1) == DataTable(a = collect(1:5), b = fill(1, 5))
+        @test DataTable(a = 1, b = 1:5) == DataTable(a = fill(1, 5), b = collect(1:5))
+    end
+
+    @testset "constructor errors" begin
+        @test_throws DimensionMismatch DataTable(a=1, b=[])
+        @test_throws DimensionMismatch DataTable(Any[collect(1:10)], DataTables.Index([:A, :B]))
+        @test_throws DimensionMismatch DataTable(A = rand(2,2))
+        @test_throws DimensionMismatch DataTable(A = rand(2,1))
+    end
+
+    @testset "column types" begin
+        dt = DataTable(A = 1:3, B = 2:4, C = 3:5)
+        answer = Any[Array{Int,1}, Array{Int,1}, Array{Int,1}]
+        @test map(typeof, dt.columns) == answer
+        dt[:D] = NullableArray([4, 5, Nullable()])
+        push!(answer, NullableArray{Int,1})
+        @test map(typeof, dt.columns) == answer
+        dt[:E] = 'c'
+        push!(answer, Array{Char,1})
+        @test map(typeof, dt.columns) == answer
+    end
 end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -22,8 +22,8 @@ module TestConversions
     @test isa(convert(Array{Float64}, dt), Matrix{Float64})
 
     dt = DataTable()
-    dt[:A] = 1.0:5.0
-    dt[:B] = 1.0:5.0
+    dt[:A] = NullableArray(1.0:5.0)
+    dt[:B] = NullableArray(1.0:5.0)
     a = convert(Array, dt)
     aa = convert(Array{Any}, dt)
     ai = convert(Array{Int}, dt)
@@ -47,9 +47,9 @@ module TestConversions
     @test isa(nai, NullableMatrix{Int})
     @test isequal(nai, convert(NullableMatrix{Int}, dt))
 
-    a = [1.0,2.0]
-    b = [-0.1,3]
-    c = [-3.1,7]
+    a = NullableArray([1.0,2.0])
+    b = NullableArray([-0.1,3])
+    c = NullableArray([-3.1,7])
     di = Dict("a"=>a, "b"=>b, "c"=>c)
 
     dt = convert(DataTable,di)
@@ -77,6 +77,6 @@ module TestConversions
 
     a = [1.0]
     di = Dict("a"=>a, "b"=>b, "c"=>c)
-    @test_throws ArgumentError convert(DataTable,di)
+    @test_throws DimensionMismatch convert(DataTable,di)
 
 end

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -34,7 +34,8 @@ module TestDataTable
     # Copying
     #
 
-    dt = DataTable(a = [2, 3], b = Any[DataTable(c = 1), DataTable(d = 2)])
+    dt = DataTable(a = NullableArray([2, 3]),
+                   b = NullableArray([DataTable(c = 1), DataTable(d = 2)]))
     dtc = copy(dt)
     dtdc = deepcopy(dt)
 
@@ -68,14 +69,16 @@ module TestDataTable
     @test_throws ErrorException x0[:d] = 1:3
 
     # Insert single value
-    x[:d] = 3
+    x[:d] = Nullable(3)
     @test isequal(x[:d], NullableArray([3, 3, 3]))
 
     x0[:d] = 3
     @test x0[:d] == Int[]
 
     # similar / nulls
-    dt = DataTable(a = 1, b = "b", c = CategoricalArray([3.3]))
+    dt = DataTable(a = NullableArray([1]),
+                   b = NullableArray(["b"]),
+                   c = NullableCategoricalArray([3.3]))
     nulldt = DataTable(a = NullableArray{Int}(2),
                        b = NullableArray{String}(2),
                        c = NullableCategoricalArray{Float64}(2))
@@ -94,7 +97,7 @@ module TestDataTable
     @test isempty(dt.columns)
     @test isempty(dt)
 
-    dt = DataTable(a=[1, 2], b=[3., 4.])
+    dt = DataTable(a=NullableArray([1, 2]), b=NullableArray([3., 4.]))
     @test_throws BoundsError insert!(dt, 5, ["a", "b"], :newcol)
     @test_throws ErrorException insert!(dt, 1, ["a"], :newcol)
     @test isequal(insert!(dt, 1, ["a", "b"], :newcol), dt)
@@ -109,7 +112,7 @@ module TestDataTable
     @test isequal(dt, DataTable(a=[1, 2], b=["a", "b"], c=[:c, :d]))
 
     #test_group("Empty DataTable constructors")
-    dt = DataTable(Int, 10, 3)
+    dt = DataTable(Nullable{Int}, 10, 3)
     @test size(dt, 1) == 10
     @test size(dt, 2) == 3
     @test typeof(dt[:, 1]) == NullableVector{Int}
@@ -119,7 +122,7 @@ module TestDataTable
     @test allnull(dt[:, 2])
     @test allnull(dt[:, 3])
 
-    dt = DataTable(Any[Int, Float64, String], 100)
+    dt = DataTable([Nullable{Int}, Nullable{Float64}, Nullable{String}], 100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
     @test typeof(dt[:, 1]) == NullableVector{Int}
@@ -129,7 +132,7 @@ module TestDataTable
     @test allnull(dt[:, 2])
     @test allnull(dt[:, 3])
 
-    dt = DataTable(Any[Int, Float64, String], [:A, :B, :C], 100)
+    dt = DataTable([Nullable{Int}, Nullable{Float64}, Nullable{String}], [:A, :B, :C], 100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
     @test typeof(dt[:, 1]) == NullableVector{Int}
@@ -140,12 +143,13 @@ module TestDataTable
     @test allnull(dt[:, 3])
 
 
-    dt = DataTable(DataType[Int, Float64, Compat.UTF8String],[:A, :B, :C], [false,false,true],100)
+    dt = DataTable([Nullable{Int}, Nullable{Float64}, Nullable{String}], [:A, :B, :C],
+                   [false, false, true],100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
     @test typeof(dt[:, 1]) == NullableVector{Int}
     @test typeof(dt[:, 2]) == NullableVector{Float64}
-    @test typeof(dt[:, 3]) == NullableCategoricalVector{Compat.UTF8String,UInt32}
+    @test typeof(dt[:, 3]) == NullableCategoricalVector{String,UInt32}
     @test allnull(dt[:, 1])
     @test allnull(dt[:, 2])
     @test allnull(dt[:, 3])
@@ -166,25 +170,8 @@ module TestDataTable
     @test size(dt, 2) == 5
     @test typeof(dt[:, 1]) == Vector{Float64}
 
-    #test_group("Other DataTable constructors")
-    dt = DataTable([@compat(Dict{Any,Any}(:a=>1, :b=>'c')),
-                    @compat(Dict{Any,Any}(:a=>3, :b=>'d')),
-                    @compat(Dict{Any,Any}(:a=>5))])
-    @test size(dt, 1) == 3
-    @test size(dt, 2) == 2
-    @test typeof(dt[:,:a]) == NullableVector{Int}
-    @test typeof(dt[:,:b]) == NullableVector{Char}
-
-    dt = DataTable([@compat(Dict{Any,Any}(:a=>1, :b=>'c')),
-                    @compat(Dict{Any,Any}(:a=>3, :b=>'d')),
-                    @compat(Dict{Any,Any}(:a=>5))],
-                   [:a, :b])
-    @test size(dt, 1) == 3
-    @test size(dt, 2) == 2
-    @test typeof(dt[:,:a]) == NullableVector{Int}
-    @test typeof(dt[:,:b]) == NullableVector{Char}
-
-    @test DataTable(NullableArray[[1,2,3],[2.5,4.5,6.5]], [:A, :B]) == DataTable(A = [1,2,3], B = [2.5,4.5,6.5])
+    @test DataTable(NullableArray[[1,2,3],[2.5,4.5,6.5]], [:A, :B]) ==
+        DataTable(A = NullableArray([1,2,3]), B = NullableArray([2.5,4.5,6.5]))
 
     # This assignment was missing before
     dt = DataTable(Column = [:A])
@@ -308,9 +295,9 @@ module TestDataTable
     end
 
     #Check the output of unstack
-    dt = DataTable(Fish = CategoricalArray(["Bob", "Bob", "Batman", "Batman"]),
-                   Key = ["Mass", "Color", "Mass", "Color"],
-                   Value = ["12 g", "Red", "18 g", "Grey"])
+    dt = DataTable(Fish = NullableCategoricalArray(["Bob", "Bob", "Batman", "Batman"]),
+                   Key = Nullable{String}["Mass", "Color", "Mass", "Color"],
+                   Value = Nullable{String}["12 g", "Red", "18 g", "Grey"])
     # Check that reordering levels does not confuse unstack
     levels!(dt[1], ["XXX", "Bob", "Batman"])
     #Unstack specifying a row column
@@ -318,11 +305,12 @@ module TestDataTable
     #Unstack without specifying a row column
     dt3 = unstack(dt,:Key, :Value)
     #The expected output
-    dt4 = DataTable(Fish = ["XXX", "Bob", "Batman"],
+    dt4 = DataTable(Fish = Nullable{String}["XXX", "Bob", "Batman"],
                     Color = Nullable{String}[Nullable(), "Red", "Grey"],
                     Mass = Nullable{String}[Nullable(), "12 g", "18 g"])
     @test isequal(dt2, dt4)
-    @test isequal(dt3, dt4[2:3, :])
+    # first column stays as CategoricalArray in dt3
+    @test isequal(dt3[:, 2:3], dt4[2:3, 2:3])
     #Make sure unstack works with NULLs at the start of the value column
     dt[1,:Value] = Nullable()
     dt2 = unstack(dt,:Fish, :Key, :Value)
@@ -334,13 +322,14 @@ module TestDataTable
     @test !(dt[:,:] === dt)
 
     @test append!(DataTable(A = 1:2, B = 1:2), DataTable(A = 3:4, B = 3:4)) == DataTable(A=1:4, B = 1:4)
-    @test !any(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6)).columns)
-    @test all(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6), [1,2]).columns)
-    @test all(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6), [:A,:B]).columns)
-    @test find(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6), [:A]).columns) == [1]
-    @test find(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6), :A).columns) == [1]
-    @test find(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6), [1]).columns) == [1]
-    @test find(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6), 1).columns) == [1]
+    dt = DataTable(A = NullableArray(1:3), B = NullableArray(4:6))
+    @test !any(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt)).columns)
+    @test all(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), [1,2]).columns)
+    @test all(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), [:A,:B]).columns)
+    @test find(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), [:A]).columns) == [1]
+    @test find(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), :A).columns) == [1]
+    @test find(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), [1]).columns) == [1]
+    @test find(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), 1).columns) == [1]
 
     @testset "unstack nullable promotion" begin
         dt = DataTable(Any[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -3,9 +3,9 @@ module TestGrouping
     using DataTables
 
     srand(1)
-    dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
-                   b = repeat([2, 1], outer=[4]),
-                   c = randn(8))
+    dt = DataTable(a = NullableArray(repeat([1, 2, 3, 4], outer=[2])),
+                   b = NullableArray(repeat([2, 1], outer=[4])),
+                   c = NullableArray(randn(8)))
     #dt[6, :a] = Nullable()
     #dt[7, :b] = Nullable()
 
@@ -125,7 +125,7 @@ module TestGrouping
     ga = map(f, gd)
     @test sbdt == combine(ga)
 
-    g(dt) = DataTable(cmax1 = Vector(dt[:cmax]) + 1)
+    g(dt) = DataTable(cmax1 = [get(c) + 1 for c in dt[:cmax]])
     h(dt) = g(f(dt))
 
     @test isequal(combine(map(h, gd)), combine(map(g, ga)))
@@ -147,7 +147,7 @@ module TestGrouping
 
     dt2 = by(e->1, DataTable(x=Int64[]), :x)
     @test size(dt2) == (0,1)
-    @test isequal(sum(dt2[:x]), Nullable(0))
+    @test isequal(sum(dt2[:x]), 0)
 
     # Check that reordering levels does not confuse groupby
     dt = DataTable(Key1 = CategoricalArray(["A", "A", "B", "B"]),

--- a/test/index.jl
+++ b/test/index.jl
@@ -57,6 +57,6 @@ end
 dt = DataTable(A=[0],B=[0])
 dt[1:end] = 0.0
 dt[1,:A] = 1.0
-@test dt[1,:B] === Nullable(0)
+@test dt[1,:B] === 0
 
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -49,7 +49,7 @@ module TestIO
                    F = NullableArray(fill(Nullable(), 3)),
                    G = fill(Nullable(), 3))
 
-    answer = Sys.WORD_SIZE == 64 ? 0x937e94e70d642cce : 0x2b8864d8
+    answer = Sys.WORD_SIZE == 64 ? 0x3bd4a4a099ae8aac : 0x5ecdc4bb
     @test hash(sprint(printtable, dt)) == answer
 
     # DataStreams

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -5,7 +5,7 @@ module TestIteration
     dm = NullableArray([1 2; 3 4])
     dt = NullableArray(zeros(2, 2, 2))
 
-    dt = DataTable(A = 1:2, B = 2:3)
+    dt = DataTable(A = NullableArray(1:2), B = NullableArray(2:3))
 
     for row in eachrow(dt)
         @test isa(row, DataTableRow)
@@ -20,7 +20,7 @@ module TestIteration
     end
 
     @test isequal(map(x -> minimum(convert(Array, x)), eachrow(dt)), Any[1,2])
-    @test isequal(map(minimum, eachcol(dt)), DataTable(A = [1], B = [2]))
+    @test isequal(map(minimum, eachcol(dt)), DataTable(A = Nullable[1], B = Nullable[2]))
 
     row = DataTableRow(dt, 1)
 
@@ -30,7 +30,7 @@ module TestIteration
     row[1] = 101
     @test isequal(dt[1, :A], Nullable(101))
 
-    dt = DataTable(A = 1:4, B = ["M", "F", "F", "M"])
+    dt = DataTable(A = NullableArray(1:4), B = NullableArray(["M", "F", "F", "M"]))
 
     s1 = view(dt, 1:3)
     s1[2,:A] = 4

--- a/test/join.jl
+++ b/test/join.jl
@@ -2,8 +2,10 @@ module TestJoin
     using Base.Test
     using DataTables
 
-    name = DataTable(ID = [1, 2, 3], Name = ["John Doe", "Jane Doe", "Joe Blogs"])
-    job = DataTable(ID = [1, 2, 2, 4], Job = ["Lawyer", "Doctor", "Florist", "Farmer"])
+    name = DataTable(ID = NullableArray([1, 2, 3]),
+                     Name = NullableArray(["John Doe", "Jane Doe", "Joe Blogs"]))
+    job = DataTable(ID = NullableArray([1, 2, 2, 4]),
+                    Job = NullableArray(["Lawyer", "Doctor", "Florist", "Farmer"]))
 
     # Join on symbols or vectors of symbols
     join(name, job, on = :ID)
@@ -13,9 +15,9 @@ module TestJoin
     #@test_throws join(name, job)
 
     # Test output of various join types
-    outer = DataTable(ID = [1, 2, 2, 3, 4],
-                      Name = NullableArray(Nullable{String}["John Doe", "Jane Doe", "Jane Doe", "Joe Blogs", Nullable()]),
-                      Job = NullableArray(Nullable{String}["Lawyer", "Doctor", "Florist", Nullable(), "Farmer"]))
+    outer = DataTable(ID = NullableArray([1, 2, 2, 3, 4]),
+                      Name = NullableArray(["John Doe", "Jane Doe", "Jane Doe", "Joe Blogs", Nullable()]),
+                      Job = NullableArray(["Lawyer", "Doctor", "Florist", Nullable(), "Farmer"]))
 
     # (Tests use current column ordering but don't promote it)
     right = outer[Bool[!isnull(x) for x in outer[:Job]], [:ID, :Name, :Job]]
@@ -112,9 +114,9 @@ module TestJoin
 
     # Test that join works when mixing Array and NullableArray (#1151)
     dt = DataTable([collect(1:10), collect(2:11)], [:x, :y])
-    dtnull = DataTable(x = 1:10, z = 3:12)
+    dtnull = DataTable(x = NullableArray(1:10), z = NullableArray(3:12))
     @test join(dt, dtnull, on = :x) ==
         DataTable([collect(1:10), collect(2:11), NullableArray(3:12)], [:x, :y, :z])
     @test join(dtnull, dt, on = :x) ==
-        DataTable([NullableArray(1:10), NullableArray(3:12), NullableArray(2:11)], [:x, :z, :y])
+        DataTable([NullableArray(1:10), NullableArray(3:12), collect(2:11)], [:x, :z, :y])
 end


### PR DESCRIPTION
Consolidating the constructors minimized the number of places where
auto promotion could take place. The new constructor recycles scalars
such that if DataTable is created with a mix of scalars and vectors
the scalars will be recycled to the same length as the vectors. Fixes an
outstanding bug where scalar recycling only worked if the scalar
assignments came after the vector assignments of the desired length, see:
https://github.com/JuliaStats/DataFrames.jl/pull/882. Tests that
used to assume NullableArray promotion now explicitly use NullableArrays
and new constructor tests have been added to test changes.

This is dependent on https://github.com/JuliaStats/NullableArrays.jl/pull/189 as I've re-used the `_isnullable` function added in that PR for more robust nullability checking.