### PR TITLE
Stack should use similar_nullable, not NullableArray

### DIFF
--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -15,6 +15,9 @@ similar_nullable{T,R}(dv::CategoricalArray{T,R}, dims::@compat(Union{Int, Tuple{
 similar_nullable(dt::AbstractDataTable, dims::Int) =
     DataTable(Any[similar_nullable(x, dims) for x in columns(dt)], copy(index(dt)))
 
+similar_nullable{T,R}(dv::NullableCategoricalArray{T,R}, dims::Union{Int, Tuple{Vararg{Int}}}) =
+    NullableCategoricalArray{T}(dims)
+
 # helper structure for DataTables joining
 immutable DataTableJoiner{DT1<:AbstractDataTable, DT2<:AbstractDataTable}
     dtl::DT1

--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -3,14 +3,14 @@
 ##
 
 # Like similar, but returns a nullable array
-similar_nullable{T}(dv::AbstractArray{T}, dims::@compat(Union{Int, Tuple{Vararg{Int}}})) =
-    NullableArray(T, dims)
+similar_nullable{T}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
+    NullableArray{T}(dims)
 
-similar_nullable{T<:Nullable}(dv::AbstractArray{T}, dims::@compat(Union{Int, Tuple{Vararg{Int}}})) =
-    NullableArray(eltype(T), dims)
+similar_nullable{T<:Nullable}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
+    NullableArray{eltype(T)}(dims)
 
-similar_nullable{T,R}(dv::CategoricalArray{T,R}, dims::@compat(Union{Int, Tuple{Vararg{Int}}})) =
-    NullableCategoricalArray(T, dims)
+similar_nullable{T,R}(dv::CategoricalArray{T,R}, dims::Union{Int, Tuple{Vararg{Int}}}) =
+    NullableCategoricalArray{T}(dims)
 
 similar_nullable(dt::AbstractDataTable, dims::Int) =
     DataTable(Any[similar_nullable(x, dims) for x in columns(dt)], copy(index(dt)))

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -342,6 +342,24 @@ module TestDataTable
     @test find(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6), [1]).columns) == [1]
     @test find(c -> isa(c, NullableCategoricalArray), categorical!(DataTable(A=1:3, B=4:6), 1).columns) == [1]
 
+    @testset "unstack nullable promotion" begin
+        dt = DataTable(Any[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
+                       [:id, :variable, :value])
+        udt = unstack(dt)
+        @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
+        @test udt == DataTable(Any[Nullable[1, 2], Nullable[1, 5], Nullable[2, 6],
+                                   Nullable[3, 7], Nullable[4, 8]], [:id, :a, :b, :c, :d])
+        @test all(typeof.(udt.columns) .== NullableVector{Int})
+        dt = DataTable(Any[categorical(repeat(1:2, inner=4)),
+                           categorical(repeat('a':'d', outer=2)), categorical(1:8)],
+                       [:id, :variable, :value])
+        udt = unstack(dt)
+        @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
+        @test udt == DataTable(Any[Nullable[1, 2], Nullable[1, 5], Nullable[2, 6],
+                                   Nullable[3, 7], Nullable[4, 8]], [:id, :a, :b, :c, :d])
+        @test all(typeof.(udt.columns) .== NullableCategoricalVector{Int, UInt32})
+    end
+
     @testset "duplicate entries in unstack warnings" begin
         dt = DataTable(id=NullableArray([1, 2, 1, 2]), variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
         @static if VERSION >= v"0.6.0-dev.1980"


### PR DESCRIPTION
- Adds a test set to trigger multiple entries in unstack warning
- Adds a similar_nullable function for NullableCategoricalArrays
- Tests to make sure column types are converted to their appropriate nullable type.