### PR TITLE
Fix printing CategoricalValue

### DIFF
--- a/src/abstractdatatable/io.jl
+++ b/src/abstractdatatable/io.jl
@@ -5,17 +5,11 @@
 ##############################################################################
 
 function escapedprint(io::IO, x::Any, escapes::AbstractString)
-    print(io, x)
+    ourshowcompact(io, x)
 end
 
-if VERSION < v"0.5.0-dev+4354"
-    function escapedprint(io::IO, x::AbstractString, escapes::AbstractString)
-        print_escaped(io, x, escapes)
-    end
-else
-    function escapedprint(io::IO, x::AbstractString, escapes::AbstractString)
-        escape_string(io, x, escapes)
-    end
+function escapedprint(io::IO, x::AbstractString, escapes::AbstractString)
+    escape_string(io, x, escapes)
 end
 
 function printtable(io::IO,
@@ -172,7 +166,7 @@ function Base.show(io::IO, ::MIME"text/latex", dt::AbstractDataTable)
                 if mimewritable(MIME("text/latex"), content)
                     show(io, MIME("text/latex"), content)
                 else
-                    print(io, latex_escape(string(content)))
+                    print(io, latex_escape(sprint(ourshowcompact, content)))
                 end
             end
         end

--- a/src/abstractdatatable/show.jl
+++ b/src/abstractdatatable/show.jl
@@ -64,7 +64,10 @@ end
 ourshowcompact(io::IO, x::Any) = showcompact(io, x) # -> Void
 ourshowcompact(io::IO, x::AbstractString) = print(io, x) # -> Void
 ourshowcompact(io::IO, x::Symbol) = print(io, x) # -> Void
-ourshowcompact(io::IO, x::Nullable{String}) = isnull(x) ? showcompact(io, x) : print(io, get(x)) # -> Void
+ourshowcompact{T<:AbstractString}(io::IO, x::CategoricalValue{T}) =
+    print(io, String(x)) # -> Void
+ourshowcompact(io::IO, x::Nullable) =
+    isnull(x) ? showcompact(io, x) : ourshowcompact(io, unsafe_get(x)) # -> Void
 
 #' @description
 #'

--- a/test/io.jl
+++ b/test/io.jl
@@ -9,26 +9,32 @@ module TestIO
     dt = DataTable(A = 1:4,
                    B = ["\$10.0", "M&F", "A~B", "\\alpha"],
                    C = [L"\alpha", L"\beta", L"\gamma", L"\sum_{i=1}^n \delta_i"],
-                   D = [1.0, 2.0, Nullable(), 3.0]
+                   D = [1.0, 2.0, Nullable(), 3.0],
+                   E = NullableCategoricalArray(["a", Nullable(), "c", "d"])
                    )
     str = """
-        \\begin{tabular}{r|cccc}
-        \t& A & B & C & D\\\\
+        \\begin{tabular}{r|ccccc}
+        \t& A & B & C & D & E\\\\
         \t\\hline
-        \t1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 \\\\
-        \t2 & 2 & M\\&F & \$\\beta\$ & 2.0 \\\\
-        \t3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  \\\\
-        \t4 & 4 & \\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 \\\\
+        \t1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 & a \\\\
+        \t2 & 2 & M\\&F & \$\\beta\$ & 2.0 &  \\\\
+        \t3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  & c \\\\
+        \t4 & 4 & \\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 & d \\\\
         \\end{tabular}
         """
     @test reprmime(MIME("text/latex"), dt) == str
 
     #Test HTML output for IJulia and similar
-    dt = DataTable(Fish = ["Suzy", "Amir"], Mass = [1.5, Nullable()])
+    dt = DataTable(Fish = ["Suzy", "Amir"], Mass = [1.5, Nullable()],
+                   E = NullableCategoricalArray(["a", Nullable()]))
     io = IOBuffer()
     show(io, "text/html", dt)
     str = String(take!(io))
-    @test str == "<table class=\"data-frame\"><tr><th></th><th>Fish</th><th>Mass</th></tr><tr><th>1</th><td>Suzy</td><td>1.5</td></tr><tr><th>2</th><td>Amir</td><td>#NULL</td></tr></table>"
+    @test str ==
+        "<table class=\"data-frame\"><tr><th></th><th>Fish</th><th>Mass</th><th>E</th></tr>" *
+        "<tr><th>1</th><td>Suzy</td><td>1.5</td><td>a</td></tr>" *
+        "<tr><th>2</th><td>Amir</td><td>#NULL</td><td>#NULL</td></tr></table>"
+
 
     # test limit attribute of IOContext is used
     dt = DataTable(a=collect(1:1000))
@@ -45,12 +51,17 @@ module TestIO
                    C = ["A", "B", "C"],
                    D = CategoricalArray('a':'c'),
                    E = NullableCategoricalArray(["A", "B", "C"]),
-                   E = NullableArray(1:3),
-                   F = NullableArray(fill(Nullable(), 3)),
-                   G = fill(Nullable(), 3))
+                   F = NullableArray(1:3),
+                   G = NullableArray(fill(Nullable(), 3)),
+                   H = fill(Nullable(), 3))
 
-    answer = Sys.WORD_SIZE == 64 ? 0x3bd4a4a099ae8aac : 0x5ecdc4bb
-    @test hash(sprint(printtable, dt)) == answer
+    @test sprint(printtable, dt) == """
+        \"A\",\"B\",\"C\",\"D\",\"E\",\"F\",\"G\",\"H\"
+        1,\"'a'\",\"A\",\"'a'\",\"A\",\"1\",NULL,NULL
+        2,\"'b'\",\"B\",\"'b'\",\"B\",\"2\",NULL,NULL
+        3,\"'c'\",\"C\",\"'c'\",\"C\",\"3\",NULL,NULL
+        """
+
 
     # DataStreams
     using CSV

--- a/test/show.jl
+++ b/test/show.jl
@@ -38,16 +38,17 @@ module TestShow
     show(io, A)
 
     #Test show output for REPL and similar
-    dt = DataTable(Fish = ["Suzy", "Amir"], Mass = [1.5, Nullable()])
+    dt = DataTable(Fish = ["Suzy", "Amir"], Mass = [1.5, Nullable()],
+                   E = NullableCategoricalArray(["a", Nullable()]))
     io = IOBuffer()
     show(io, dt)
     str = String(take!(io))
     @test str == """
-    2×2 DataTables.DataTable
-    │ Row │ Fish │ Mass  │
-    ├─────┼──────┼───────┤
-    │ 1   │ Suzy │ 1.5   │
-    │ 2   │ Amir │ #NULL │"""
+    2×3 DataTables.DataTable
+    │ Row │ Fish │ Mass  │ E     │
+    ├─────┼──────┼───────┼───────┤
+    │ 1   │ Suzy │ 1.5   │ a     │
+    │ 2   │ Amir │ #NULL │ #NULL │"""
 
     # Test computing width for Array{String} columns
     dt = DataTable(Any[["a"]], [:x])


### PR DESCRIPTION
CategoricalValue entries should always be printed via showcompact() in order
to get a short representation. This uses ourshowcompact() to do that when
printing DataTables to REPL via show, as well as when printing them to HTML,
LaTeX and CSV via printtable().

Also fix a failure due to duplicated keyword arguments on Julia 0.7, which is needed for https://github.com/JuliaData/DataTables.jl/pull/72.