### PR TITLE
Specialize row_group_slots() and findrow() on column types to improve performance

### DIFF
--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -141,9 +141,11 @@ function update_row_maps!(left_table::AbstractDataTable,
     @inline update!(mask::Vector{Bool}, orig_ixs::AbstractArray) = (mask[orig_ixs] = false)
 
     # iterate over left rows and compose the left<->right index map
+    right_dict_cols = ntuple(i -> right_dict.dt[i], ncol(right_dict.dt))
+    left_table_cols = ntuple(i -> left_table[i], ncol(left_table))
     next_join_ix = 1
     for l_ix in 1:nrow(left_table)
-        r_ixs = findrows(right_dict, left_table, l_ix)
+        r_ixs = findrows(right_dict, left_table, right_dict_cols, left_table_cols, l_ix)
         if isempty(r_ixs)
             update!(leftonly_ixs, l_ix, next_join_ix)
             next_join_ix += 1
@@ -284,8 +286,10 @@ function Base.join(dt1::AbstractDataTable,
         # iterate over left rows and leave those found in right
         left_ixs = Vector{Int}()
         sizehint!(left_ixs, nrow(joiner.dtl))
+        dtr_on_grp_cols = ntuple(i -> dtr_on_grp.dt[i], ncol(dtr_on_grp.dt))
+        dtl_on_cols = ntuple(i -> joiner.dtl_on[i], ncol(joiner.dtl_on))
         @inbounds for l_ix in 1:nrow(joiner.dtl_on)
-            if findrow(dtr_on_grp, joiner.dtl_on, l_ix) != 0
+            if findrow(dtr_on_grp, joiner.dtl_on, dtr_on_grp_cols, dtl_on_cols, l_ix) != 0
                 push!(left_ixs, l_ix)
             end
         end
@@ -296,8 +300,10 @@ function Base.join(dt1::AbstractDataTable,
         # iterate over left rows and leave those not found in right
         leftonly_ixs = Vector{Int}()
         sizehint!(leftonly_ixs, nrow(joiner.dtl))
+        dtr_on_grp_cols = ntuple(i -> dtr_on_grp.dt[i], ncol(dtr_on_grp.dt))
+        dtl_on_cols = ntuple(i -> joiner.dtl_on[i], ncol(joiner.dtl_on))
         @inbounds for l_ix in 1:nrow(joiner.dtl_on)
-            if findrow(dtr_on_grp, joiner.dtl_on, l_ix) == 0
+            if findrow(dtr_on_grp, joiner.dtl_on, dtr_on_grp_cols, dtl_on_cols, l_ix) == 0
                 push!(leftonly_ixs, l_ix)
             end
         end

--- a/test/datatablerow.jl
+++ b/test/datatablerow.jl
@@ -67,8 +67,7 @@ module TestDataTableRow
     # getting groups for the rows of the other frames
     @test length(gd[DataTableRow(dt6, 1)]) > 0
     @test_throws KeyError gd[DataTableRow(dt6, 2)]
-    @test isempty(DataTables.findrows(gd, dt6, 2))
-    @test length(DataTables.findrows(gd, dt6, 2)) == 0
+    @test isempty(DataTables.findrows(gd, dt6, (gd.dt[1],), (dt6[1],), 2))
 
     # grouping empty frame
     gd = DataTables.group_rows(DataTable(x=Int[]))


### PR DESCRIPTION
Looping over columns is very slow when their type is unknown at compile time.
Specialize the method on the types of the key (grouping) columns by passing
a tuple of columns rather than a DataTable. This will force compiling a specific
method for each combination of key types, but their number should remain relatively low
and the one-time cost is worth it.

This dramatically improves performance of groupby(), but does not have a large
effect on join() since it is very inefficient in other areas.

----------

This is an alternative to https://github.com/JuliaData/DataTables.jl/pull/76. We should probably merge it anyway, even if we merge https://github.com/JuliaData/DataTables.jl/pull/76 later, as it improves the performance of the current algorithm, making it possible to compare the merits of both approaches.

In the simple test used in #76, this makes grouping faster than DataFrames, and even slightly faster than #76. More benchmarks would be needed to check whether this is also the case for other scenarios. Unfortunately, `join` remains much slower than DataFrames for unrelated reasons.

The downside of this change is that the method will be recompiled for each combination of column types used for grouping. I think that's OK since the number of grouping columns is generally low, and the number of different types is limited too. Though I should note the approach in #76 only compiles one method for each column types, not for each of their combinations.

Cc: @cjprybol @alyst