### PR TITLE
Get PR 66 passing tests on Julia 0.7

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -2,88 +2,109 @@
 
 ## Installation
 
-The DataTables package is available through the Julia package system. Throughout the rest of this tutorial, we will assume that you have installed the DataTables package and have already typed `using NullableArrays, DataTables` to bring all of the relevant variables into your current namespace. In addition, we will make use of the `RDatasets` package, which provides access to hundreds of classical data sets.
+The DataTables package is available through the Julia package system. Throughout the rest of this tutorial, we will assume that you have installed the DataTables package and have already typed `using DataTables` to bring all of the relevant variables into your current namespace.
 
-## The `Nullable` Type
+## The `Null` Type
 
-To get started, let's examine the `Nullable` type. Objects of this type can either hold a value, or represent a missing value (`null`). For example, this is a `Nullable` holding the integer `1`:
-
-```julia
-Nullable(1)
-```
-
-And this represents a missing value:
-```julia
-Nullable()
-```
-
-`Nullable` objects support all standard operators, which return another `Nullable`. One of the essential properties of `null` values is that they poison other items. To see this, try to add something like `Nullable(1)` to `Nullable()`:
+To get started, let's examine the `Null` type. `Null` is a type implemented by [Nulls.jl](https://github.com/JuliaData/Nulls.jl) to represent missing data. `null` is an instance of the type `Null` used to represent a missing value.
 
 ```julia
-Nullable(1) + Nullable()
+julia> using DataTables
+
+julia> null
+null
+
+julia> typeof(null)
+Nulls.Null
+
 ```
 
-The `get` function can be used to extract the value from the [`Nullable`](http://docs.julialang.org/en/stable/manual/types/#nullable-types-representing-missing-values) wrapper when it is not null. For example:
+The `Null` type lets users create `Vector`s and `DataTable` columns with missing values. Here we create a vector with a null value and the element-type of the returned vector is `Union{Nulls.Null, Int64}`.
 
 ```julia
-julia> a = Nullable("14:00:00")
-Nullable{String}("14:00:00")
+julia> x = [1, 2, null]
+3-element Array{Union{Nulls.Null, Int64},1}:
+ 1
+ 2
+  null
 
-julia> b = get(a)
-"14:00:00"
+julia> eltype(x)
+Union{Nulls.Null, Int64}
 
-julia> typeof(b)
-String
+julia> Union{Int, Null}
+Union{Nulls.Null, Int64}
+
+julia> eltype(x) == Union{Int, Null}
+true
+
 ```
 
-Note that operations mixing `Nullable` and scalars (e.g. `1 + Nullable(1)`) are not supported.
-
-## The `NullableArray` Type
-
-`Nullable` objects can be stored in a standard `Array` just like any value:
+`null` values can be excluded when performing operations by using `Nulls.skip`, which returns a memory-efficient iterator.
 
 ```julia
-v = Nullable{Int}[1, 3, 4, 5, 4]
+julia> Nulls.skip(x)
+Base.Generator{Base.Iterators.Filter{Nulls.##4#6{Nulls.Null},Array{Union{Nulls.Null, Int64},1}},Nulls.##3#5}(Nulls.#3, Base.Iterators.Filter{Nulls.##4#6{Nulls.Null},Array{Union{Nulls.Null, Int64},1}}(Nulls.#4, Union{Nulls.Null, Int64}[1, 2, null]))
+
 ```
 
-But arrays of `Nullable` are inefficient, both in terms of computation costs and of memory use. `NullableArrays` provide a more efficient storage, and behave like `Array{Nullable}` objects.
+The output of `Nulls.skip` can be passed directly into functions as an argument. For example, we can find the `sum` of all non-null values or `collect` the non-null values into a new null-free vector.
 
 ```julia
-nv = NullableArray(Nullable{Int}[Nullable(), 3, 2, 5, 4])
+julia> sum(Nulls.skip(x))
+3
+
+julia> collect(Nulls.skip(x))
+2-element Array{Int64,1}:
+ 1
+ 2
+
 ```
 
-In many cases we're willing to just ignore missing values and remove them from our vector. We can do that using the `dropnull` function:
+`null` elements can be replaced with other values via `Nulls.replace`.
 
 ```julia
-dropnull(nv)
-mean(dropnull(nv))
+julia> collect(Nulls.replace(x, 1))
+3-element Array{Int64,1}:
+ 1
+ 2
+ 1
+
 ```
 
-Instead of removing `null` values, you can try to convert the `NullableArray` into a normal Julia `Array` using `convert`:
+The function `Nulls.T` returns the element-type `T` in `Union{T, Null}`.
 
 ```julia
-convert(Array, nv)
+julia> Nulls.T(eltype(x))
+Int64
+
 ```
 
-This fails in the presence of `null` values, but will succeed if there are no `null` values:
+Use `nulls` to generate nullable `Vector`s and `Array`s, using the optional first argument to specify the element-type.
 
 ```julia
-nv[1] = 3
-convert(Array, nv)
+julia> nulls(1)
+1-element Array{Nulls.Null,1}:
+ null
+
+julia> nulls(3)
+3-element Array{Nulls.Null,1}:
+ null
+ null
+ null
+
+julia> nulls(1, 3)
+1×3 Array{Nulls.Null,2}:
+ null  null  null
+
+julia> nulls(Int, 1, 3)
+1×3 Array{Union{Nulls.Null, Int64},2}:
+ null  null  null
+
 ```
-
-In addition to removing `null` values and hoping they won't occur, you can also replace any `null` values using the `convert` function, which takes a replacement value as an argument:
-
-```julia
-nv = NullableArray(Nullable{Int}[Nullable(), 3, 2, 5, 4])
-mean(convert(Array, nv, 0))
-```
-
-Which strategy for dealing with `null` values is most appropriate will typically depend on the specific details of your data analysis pathway.
 
 ## The `DataTable` Type
 
-The `DataTable` type can be used to represent data tables, each column of which is an array (by default, a `NullableArray`). You can specify the columns using keyword arguments:
+The `DataTable` type can be used to represent data tables, each column of which is a vector. You can specify the columns using keyword arguments:
 
 ```julia
 dt = DataTable(A = 1:4, B = ["M", "F", "F", "M"])
@@ -123,22 +144,22 @@ describe(dt)
 To focus our search, we start looking at just the means and medians of specific columns. In the example below, we use numeric indexing to access the columns of the `DataTable`:
 
 ```julia
-mean(dropnull(dt[1]))
-median(dropnull(dt[1]))
+mean(Nulls.skip(dt[1]))
+median(Nulls.skip(dt[1]))
 ```
 
 We could also have used column names to access individual columns:
 
 ```julia
-mean(dropnull(dt[:A]))
-median(dropnull(dt[:A]))
+mean(Nulls.skip(dt[:A]))
+median(Nulls.skip(dt[:A]))
 ```
 
 We can also apply a function to each column of a `DataTable` with the `colwise` function. For example:
 
 ```julia
 dt = DataTable(A = 1:4, B = randn(4))
-colwise(c->cumsum(dropnull(c)), dt)
+colwise(c->cumsum(Nulls.skip(c)), dt)
 ```
 
 ## Importing and Exporting Data (I/O)
@@ -178,9 +199,7 @@ For more information, use the REPL [help-mode](http://docs.julialang.org/en/stab
 
 ## Accessing Classic Data Sets
 
-To see more of the functionality for working with `DataTable` objects, we need a more complex data set to work with. We'll use the `RDatasets` package, which provides access to many of the classical data sets that are available in R.
-
-For example, we can access Fisher's iris data set using the following functions:
+To see more of the functionality for working with `DataTable` objects, we need a more complex data set to work with. We can access Fisher's iris data set using the following functions:
 
 ```julia
 using CSV

--- a/docs/src/man/pooling.md
+++ b/docs/src/man/pooling.md
@@ -7,14 +7,20 @@ v = ["Group A", "Group A", "Group A",
      "Group B", "Group B", "Group B"]
 ```
 
-The naive encoding used in an `Array` or in a `NullableArray` represents every entry of this vector as a full string. In contrast, we can represent the data more efficiently by replacing the strings with indices into a small pool of levels. This is what the `CategoricalArray` type does:
+The naive encoding used in an `Array` represents every entry of this vector as a full string. In contrast, we can represent the data more efficiently by replacing the strings with indices into a small pool of levels. This is what the `CategoricalArray` type does:
 
 ```julia
 cv = CategoricalArray(["Group A", "Group A", "Group A",
                        "Group B", "Group B", "Group B"])
 ```
 
-A companion type, `NullableCategoricalArray`, allows storing missing values in the array: is to `CategoricalArray` what `NullableArray` is to the standard `Array` type.
+`CategoricalArrays` support missing values via the `Nulls` package.
+
+```julia
+using Nulls
+cv = CategoricalArray(["Group A", null, "Group A",
+                       "Group B", "Group B", null])
+```
 
 In addition to representing repeated data efficiently, the `CategoricalArray` type allows us to determine efficiently the allowed levels of the variable at any time using the `levels` function (note that levels may or may not be actually used in the data):
 
@@ -30,7 +36,7 @@ By default, a `CategoricalArray` is able to represent 2<sup>32</sup>differents l
 cv = compact(cv)
 ```
 
-Often, you will have factors encoded inside a DataTable with `Array` or `NullableArray` columns instead of `CategoricalArray` or `NullableCategoricalArray` columns. You can do conversion of a single column using the `categorical` function:
+Often, you will have factors encoded inside a DataTable with `Array` columns instead of `CategoricalArray` columns. You can do conversion of a single column using the `categorical` function:
 
 ```julia
 cv = categorical(v)
@@ -44,6 +50,6 @@ dt = DataTable(A = [1, 1, 1, 2, 2, 2],
 categorical!(dt, [:A, :B])
 ```
 
-Using categorical arrays is important for working with the [GLM package](https://github.com/JuliaStats/GLM.jl). When fitting regression models, `CategoricalArray` and `NullableCategoricalArray` columns in the input are translated into 0/1 indicator columns in the `ModelMatrix` with one column for each of the levels of the `CategoricalArray`/`NullableCategoricalArray`. This allows one to analyze categorical data efficiently.
+Using categorical arrays is important for working with the [GLM package](https://github.com/JuliaStats/GLM.jl). When fitting regression models, `CategoricalArray` columns in the input are translated into 0/1 indicator columns in the `ModelMatrix` with one column for each of the levels of the `CategoricalArray`. This allows one to analyze categorical data efficiently.
 
-See the [CategoricalArrays package](https://github.com/nalimilan/CategoricalArrays.jl) for more information regarding categorical arrays.
+See the [CategoricalArrays package](https://github.com/JuliaData/CategoricalArrays.jl) for more information regarding categorical arrays.

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -80,6 +80,6 @@ None of these reshaping functions perform any aggregation. To do aggregation, us
 
 ```julia
 d = stack(iris)
-x = by(d, [:variable, :Species], dt -> DataTable(vsum = mean(dropnull(dt[:value]))))
+x = by(d, [:variable, :Species], dt -> DataTable(vsum = mean(Nulls.skip(dt[:value]))))
 unstack(x, :Species, :vsum)
 ```

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -12,7 +12,7 @@ using CSV
 iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"), DataTable)
 
 by(iris, :Species, size)
-by(iris, :Species, dt -> mean(dropnull(dt[:PetalLength])))
+by(iris, :Species, dt -> mean(Nulls.skip(dt[:PetalLength])))
 by(iris, :Species, dt -> DataTable(N = size(dt, 1)))
 ```
 
@@ -20,7 +20,7 @@ The `by` function also support the `do` block form:
 
 ```julia
 by(iris, :Species) do dt
-   DataTable(m = mean(dropnull(dt[:PetalLength])), s² = var(dropnull(dt[:PetalLength])))
+   DataTable(m = mean(Nulls.skip(dt[:PetalLength])), s² = var(Nulls.skip(dt[:PetalLength])))
 end
 ```
 
@@ -30,7 +30,7 @@ We show several examples of the `aggregate` function applied to the `iris` datas
 
 ```julia
 aggregate(iris, :Species, sum)
-aggregate(iris, :Species, [sum, x->mean(dropnull(x))])
+aggregate(iris, :Species, [sum, x->mean(Nulls.skip(x))])
 ```
 
 If you only want to split the data set into subsets, use the `groupby` function:

--- a/docs/src/man/subsets.md
+++ b/docs/src/man/subsets.md
@@ -25,7 +25,7 @@ Referring to the first column by index or name:
 
 ```julia
 julia> dt[1]
-10-element NullableArrays.NullableArray{Int64,1}:
+10-element Array{Int64,1}:
   1
   2
   3
@@ -38,7 +38,7 @@ julia> dt[1]
  10
 
 julia> dt[:A]
-10-element NullableArrays.NullableArray{Int64,1}:
+10-element Array{Int64,1}:
   1
   2
   3
@@ -55,10 +55,10 @@ Refering to the first element of the first column:
 
 ```julia
 julia> dt[1, 1]
-Nullable{Int64}(1)
+1
 
 julia> dt[1, :A]
-Nullable{Int64}(1)
+1
 ```
 
 Selecting a subset of rows by index and an (ordered) subset of columns by name:

--- a/src/DataTables.jl
+++ b/src/DataTables.jl
@@ -8,9 +8,8 @@ module DataTables
 ##
 ##############################################################################
 
-using Compat, Reexport
-using StatsBase, SortingAlgorithms, Nulls
-@reexport using CategoricalArrays
+using Compat, Reexport, StatsBase, SortingAlgorithms
+@reexport using CategoricalArrays, Nulls
 
 using Base: Sort, Order
 import Base: ==, |>

--- a/src/abstractdatatable/io.jl
+++ b/src/abstractdatatable/io.jl
@@ -23,7 +23,7 @@ function printtable(io::IO,
                     header::Bool = true,
                     separator::Char = ',',
                     quotemark::Char = '"',
-                    nastring::AbstractString = "NULL")
+                    nastring::AbstractString = "null")
     n, p = size(dt)
     etypes = eltypes(dt)
     if header
@@ -68,7 +68,7 @@ function printtable(dt::AbstractDataTable;
                     header::Bool = true,
                     separator::Char = ',',
                     quotemark::Char = '"',
-                    nastring::AbstractString = "NULL")
+                    nastring::AbstractString = "null")
     printtable(STDOUT,
                dt,
                header = header,
@@ -205,7 +205,7 @@ importall DataStreams
 using WeakRefStrings
 
 # DataTables DataStreams implementation
-function Data.schema(df::DataTable, ::Type{Data.Batch})
+function Data.schema(df::DataTable, ::Type{Data.Column})
     return Data.Schema(map(string, names(df)),
                        Type[typeof(A) for A in df.columns], size(df, 1))
 end
@@ -216,14 +216,14 @@ function Data.isdone(source::DataTable, row, col)
     return row > rows || col > cols
 end
 
-Data.streamtype(::Type{DataTable}, ::Type{Data.Batch}) = true
-Data.streamtype(::Type{DataTable}, ::Type{Data.Row}) = true
+Data.streamtype(::Type{DataTable}, ::Type{Data.Column}) = true
+Data.streamtype(::Type{DataTable}, ::Type{Data.Field}) = true
 
-# Data.streamfrom{T <: AbstractVector}(source::DataTable, ::Type{Data.Batch}, ::Type{T}, col) =
+# Data.streamfrom{T <: AbstractVector}(source::DataTable, ::Type{Data.Column}, ::Type{T}, col) =
 #     (A = source.columns[col]::T; return A)
-Data.streamfrom{T}(source::DataTable, ::Type{Data.Batch}, ::Type{T}, col) =
+Data.streamfrom{T}(source::DataTable, ::Type{Data.Column}, ::Type{T}, col) =
     (A = source.columns[col]::AbstractVector{T}; return A)
-Data.streamfrom{T}(source::DataTable, ::Type{Data.Row}, ::Type{T}, row, col) =
+Data.streamfrom{T}(source::DataTable, ::Type{Data.Field}, ::Type{T}, row, col) =
     (A = source.columns[col]::AbstractVector{T}; return A[row]::T)
 
 # DataTable as a Data.Sink
@@ -231,10 +231,10 @@ allocate{T}(::Type{T}, rows) = Vector{T}(rows)
 allocate{T}(::Type{Vector{T}}, rows) = Vector{T}(rows)
 
 function DataTable{T <: Data.StreamType}(sch::Data.Schema,
-                                         ::Type{T}=Data.Row,
+                                         ::Type{T}=Data.Field,
                                          append::Bool=false)
     rows, cols = size(sch)
-    rows = max(0, T <: Data.Batch ? 0 : rows) # don't pre-allocate for Column streaming
+    rows = max(0, T <: Data.Column ? 0 : rows) # don't pre-allocate for Column streaming
     columns = Vector{Any}(cols)
     types = Data.types(sch)
     for i = 1:cols
@@ -245,27 +245,27 @@ end
 
 # given an existing DataTable (`sink`), make any necessary changes for streaming source
 # with Data.Schema `sch` to it, given we know if we'll be `appending` or not
-function DataTable(sink, sch::Data.Schema, ::Type{Data.Row}, append::Bool)
+function DataTable(sink, sch::Data.Schema, ::Type{Data.Field}, append::Bool)
     rows, cols = size(sch)
     newsize = max(0, rows) + (append ? size(sink, 1) : 0)
     newsize != size(sink, 1) && foreach(x->resize!(x, newsize), sink.columns)
     sch.rows = newsize
     return sink
 end
-function DataTable(sink, sch::Data.Schema, ::Type{Data.Batch}, append::Bool)
+function DataTable(sink, sch::Data.Schema, ::Type{Data.Column}, append::Bool)
     rows, cols = size(sch)
     append ? (sch.rows += size(sink, 1)) : foreach(empty!, sink.columns)
     return sink
 end
 
-Data.streamtypes(::Type{DataTable}) = [Data.Batch, Data.Row]
+Data.streamtypes(::Type{DataTable}) = [Data.Column, Data.Field]
 
-Data.streamto!{T}(sink::DataTable, ::Type{Data.Row}, val::T, row, col, sch::Data.Schema{false}) =
+Data.streamto!{T}(sink::DataTable, ::Type{Data.Field}, val::T, row, col, sch::Data.Schema{false}) =
     push!(sink.columns[col], val)
-Data.streamto!{T}(sink::DataTable, ::Type{Data.Row}, val::T, row, col, sch::Data.Schema{true}) =
+Data.streamto!{T}(sink::DataTable, ::Type{Data.Field}, val::T, row, col, sch::Data.Schema{true}) =
     (sink.columns[col])[row] = val
 
-function Data.streamto!{T}(sink::DataTable, ::Type{Data.Batch}, column::T, row, col, sch::Data.Schema)
+function Data.streamto!{T}(sink::DataTable, ::Type{Data.Column}, column::T, row, col, sch::Data.Schema)
     if row == 0
         sink.columns[col] = column
     else

--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -4,16 +4,13 @@
 
 # Like similar, but returns a array that can have nulls and is initialized with nulls
 similar_nullable{T}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    (v = Vector{?T}(dims); fill!(v, null); return v)
+    (v = Vector{Union{T, Null}}(dims); fill!(v, null); return v)
 
 similar_nullable{T >: Null}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    (v = Vector{?Nulls.T(T)}(dims); fill!(v, null); return v)
+    (v = Vector{T}(dims); fill!(v, null); return v)
 
 similar_nullable{T}(dv::CategoricalArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    NullableCategoricalArray{T}(dims)
-
-similar_nullable{T}(dv::NullableCategoricalArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    NullableCategoricalArray{T}(dims)
+    CategoricalArray{Union{T, Null}}(dims)
 
 # helper structure for DataTables joining
 immutable DataTableJoiner{DT1<:AbstractDataTable, DT2<:AbstractDataTable}

--- a/src/abstractdatatable/reshape.jl
+++ b/src/abstractdatatable/reshape.jl
@@ -193,9 +193,9 @@ function unstack(dt::AbstractDataTable, rowkey::Int, colkey::Int, value::Int)
     # `rowkey` integer indicating which column to place along rows
     # `colkey` integer indicating which column to place along column headers
     # `value` integer indicating which column has values
-    refkeycol = NullableCategoricalArray(dt[rowkey])
+    refkeycol = CategoricalArray{Union{eltype(dt[rowkey]), Null}}(dt[rowkey])
     valuecol = dt[value]
-    keycol = NullableCategoricalArray(dt[colkey])
+    keycol = CategoricalArray{Union{eltype(dt[colkey]), Null}}(dt[colkey])
     Nrow = length(refkeycol.pool)
     Ncol = length(keycol.pool)
     payload = DataTable(Any[similar_nullable(valuecol, Nrow) for i in 1:Ncol], map(Symbol, levels(keycol)))
@@ -230,7 +230,7 @@ function unstack(dt::AbstractDataTable, colkey::Int, value::Int)
     for i in 1:length(groupidxs)
         rowkey[groupidxs[i]] = i
     end
-    keycol = NullableCategoricalArray(dt[colkey])
+    keycol = CategoricalArray{Union{eltype(dt[colkey]), Null}}(dt[colkey])
     valuecol = dt[value]
     dt1 = nullable!(dt[g.idx[g.starts], g.cols], g.cols)
     Nrow = length(g)

--- a/src/abstractdatatable/show.jl
+++ b/src/abstractdatatable/show.jl
@@ -64,7 +64,7 @@ end
 ourshowcompact(io::IO, x::Any) = showcompact(io, x) # -> Void
 ourshowcompact(io::IO, x::AbstractString) = print(io, x) # -> Void
 ourshowcompact(io::IO, x::Symbol) = print(io, x) # -> Void
-ourshowcompact(io::IO, x::(?String)) = isnull(x) ? showcompact(io, x) : print(io, x) # -> Void
+ourshowcompact(io::IO, x::Union{String, Null}) = isnull(x) ? showcompact(io, x) : print(io, x) # -> Void
 
 #' @description
 #'

--- a/src/datatablerow/datatablerow.jl
+++ b/src/datatablerow/datatablerow.jl
@@ -39,9 +39,9 @@ Base.convert(::Type{Array}, r::DataTableRow) = convert(Array, r.dt[r.row,:])
 
 # hash column element
 Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) = hash(v[i], h)
-Base.@propagate_inbounds hash_colel{T}(v::AbstractCategoricalArray{T}, i, h::UInt = zero(UInt)) =
+Base.@propagate_inbounds hash_colel(v::AbstractCategoricalArray, i, h::UInt = zero(UInt)) =
     hash(CategoricalArrays.index(v.pool)[v.refs[i]], h)
-Base.@propagate_inbounds function hash_colel{T}(v::AbstractNullableCategoricalArray{T}, i, h::UInt = zero(UInt))
+Base.@propagate_inbounds function hash_colel(v::AbstractCategoricalArray{>: Null}, i, h::UInt = zero(UInt))
     ref = v.refs[i]
     ref == 0 ? hash(null, h) : hash(CategoricalArrays.index(v.pool)[ref], h)
 end
@@ -60,7 +60,6 @@ Base.hash(r::DataTableRow, h::UInt = zero(UInt)) = rowhash(r.dt, r.row, h)
 # comparison of DataTable rows
 # only the rows of the same DataTable could be compared
 # rows are equal if they have the same values (while the row indices could differ)
-# returns Nullable{Bool}
 # if all non-null values are equal, but there are nulls, returns null
 Base.:(==)(r1::DataTableRow, r2::DataTableRow) = isequal(r1, r2)
 

--- a/src/datatablerow/utils.jl
+++ b/src/datatablerow/utils.jl
@@ -38,9 +38,9 @@ function hashrows_col!{T}(h::Vector{UInt}, v::AbstractCategoricalVector{T})
     h
 end
 
-# should give the same hash as AbstractNullableVector{T}
+# should give the same hash as AbstractVector{T}
 # enables efficient sequential memory access pattern
-function hashrows_col!{T}(h::Vector{UInt}, v::AbstractNullableCategoricalVector{T})
+function hashrows_col!(h::Vector{UInt}, v::AbstractCategoricalVector{>: Null})
     # TODO is it possible to optimize by hashing the pool values once?
     @inbounds for (i, ref) in enumerate(v.refs)
         h[i] = ref == 0 ?

--- a/src/groupeddatatable/grouping.jl
+++ b/src/groupeddatatable/grouping.jl
@@ -72,8 +72,8 @@ vcat([g[:b] for g in gd]...)
 for g in gd
     println(g)
 end
-map(d -> mean(dropnull(d[:c])), gd)   # returns a GroupApplied object
-combine(map(d -> mean(dropnull(d[:c])), gd))
+map(d -> mean(Nulls.skip(d[:c])), gd)   # returns a GroupApplied object
+combine(map(d -> mean(Nulls.skip(d[:c])), gd))
 dt |> groupby(:a) |> [sum, length]
 dt |> groupby([:a, :b]) |> [sum, length]
 ```
@@ -187,7 +187,7 @@ combine(ga::GroupApplied)
 dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
                b = repeat([2, 1], outer=[4]),
                c = randn(8))
-combine(map(d -> mean(dropnull(d[:c])), gd))
+combine(map(d -> mean(Nulls.skip(d[:c])), gd))
 ```
 
 """
@@ -284,11 +284,11 @@ dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
                b = repeat([2, 1], outer=[4]),
                c = randn(8))
 by(dt, :a, d -> sum(d[:c]))
-by(dt, :a, d -> 2 * dropnull(d[:c]))
-by(dt, :a, d -> DataTable(c_sum = sum(d[:c]), c_mean = mean(dropnull(d[:c]))))
-by(dt, :a, d -> DataTable(c = d[:c], c_mean = mean(dropnull(d[:c]))))
+by(dt, :a, d -> 2 * Nulls.skip(d[:c]))
+by(dt, :a, d -> DataTable(c_sum = sum(d[:c]), c_mean = mean(Nulls.skip(d[:c]))))
+by(dt, :a, d -> DataTable(c = d[:c], c_mean = mean(Nulls.skip(d[:c]))))
 by(dt, [:a, :b]) do d
-    DataTable(m = mean(dropnull(d[:c])), v = var(dropnull(d[:c])))
+    DataTable(m = mean(Nulls.skip(d[:c])), v = var(Nulls.skip(d[:c])))
 end
 ```
 
@@ -334,9 +334,9 @@ dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
                b = repeat([2, 1], outer=[4]),
                c = randn(8))
 aggregate(dt, :a, sum)
-aggregate(dt, :a, [sum, x->mean(dropnull(x))])
-aggregate(groupby(dt, :a), [sum, x->mean(dropnull(x))])
-dt |> groupby(:a) |> [sum, x->mean(dropnull(x))]   # equivalent
+aggregate(dt, :a, [sum, x->mean(Nulls.skip(x))])
+aggregate(groupby(dt, :a), [sum, x->mean(Nulls.skip(x))])
+dt |> groupby(:a) |> [sum, x->mean(Nulls.skip(x))]   # equivalent
 ```
 
 """

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -111,7 +111,7 @@ end
 
 Base.getindex(x::Index, idx::Symbol) = x.lookup[idx]
 Base.getindex(x::AbstractIndex, idx::Real) = Int(idx)
-Base.getindex(x::AbstractIndex, idx::AbstractVector{?Bool}) =
+Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Null}}) =
     getindex(x, collect(Nulls.replace(idx, false)))
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool}) = find(idx)
 Base.getindex{T >: Null}(x::AbstractIndex, idx::AbstractVector{T}) =

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -124,7 +124,7 @@ end
 
 #' @description
 #'
-#' Count the number of missing values in a NullableCategoricalArray.
+#' Count the number of missing values in a CategoricalArray.
 #'
 #' @field na::CategoricalArray The CategoricalArray whose missing values
 #'        are to be counted.

--- a/src/subdatatable/subdatatable.jl
+++ b/src/subdatatable/subdatatable.jl
@@ -93,7 +93,7 @@ function SubDataTable(parent::DataTable, row::Integer)
     return SubDataTable(parent, [Int(row)])
 end
 
-function SubDataTable(parent::DataTable, rows::AbstractVector{<:?Integer})
+function SubDataTable(parent::DataTable, rows::AbstractVector{<:Union{Integer, Null}})
     return SubDataTable(parent, convert(Vector{Int}, rows))
 end
 
@@ -101,7 +101,7 @@ function SubDataTable(parent::DataTable, rows::AbstractVector{Bool})
     return SubDataTable(parent, find(rows))
 end
 
-function SubDataTable{T<:?Integer}(sdt::SubDataTable, rowinds::Union{T, AbstractVector{T}})
+function SubDataTable{T<:Union{Integer, Null}}(sdt::SubDataTable, rowinds::Union{T, AbstractVector{T}})
     return SubDataTable(sdt.parent, sdt.rows[rowinds])
 end
 

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,5 +1,5 @@
 module TestConstructors
-    using Base.Test, DataTables, Nulls, DataTables.Index
+    using Base.Test, DataTables, DataTables.Index
 
     #
     # DataTable
@@ -9,14 +9,14 @@ module TestConstructors
     @test dt.columns == Any[]
     @test dt.colindex == Index()
 
-    dt = DataTable(Any[NullableCategoricalVector(zeros(3)),
-                       NullableCategoricalVector(ones(3))],
+    dt = DataTable(Any[CategoricalVector{Union{Float64, Null}}(zeros(3)),
+                       CategoricalVector{Union{Float64, Null}}(ones(3))],
                    Index([:x1, :x2]))
     @test size(dt, 1) == 3
     @test size(dt, 2) == 2
 
-    @test dt == DataTable(Any[NullableCategoricalVector(zeros(3)),
-                              NullableCategoricalVector(ones(3))])
+    @test dt == DataTable(Any[CategoricalVector{Union{Float64, Null}}(zeros(3)),
+                              CategoricalVector{Union{Float64, Null}}(ones(3))])
     @test dt == DataTable(x1 = [0.0, 0.0, 0.0],
                           x2 = [1.0, 1.0, 1.0])
 
@@ -27,21 +27,21 @@ module TestConstructors
     @test dt[:x1] == dt2[:x1]
     @test dt[:x2] == dt2[:x2]
 
-    @test dt == DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
-                          x2 = (?Float64)[1.0, 1.0, 1.0])
-    @test dt == DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
-                          x2 = (?Float64)[1.0, 1.0, 1.0],
-                          x3 = (?Float64)[2.0, 2.0, 2.0])[[:x1, :x2]]
+    @test dt == DataTable(x1 = Union{Float64, Null}[0.0, 0.0, 0.0],
+                          x2 = Union{Float64, Null}[1.0, 1.0, 1.0])
+    @test dt == DataTable(x1 = Union{Float64, Null}[0.0, 0.0, 0.0],
+                          x2 = Union{Float64, Null}[1.0, 1.0, 1.0],
+                          x3 = Union{Float64, Null}[2.0, 2.0, 2.0])[[:x1, :x2]]
 
-    dt = DataTable(?Int, 2, 2)
+    dt = DataTable(Union{Int, Null}, 2, 2)
     @test size(dt) == (2, 2)
-    @test eltypes(dt) == [?Int, ?Int]
+    @test eltypes(dt) == [Union{Int, Null}, Union{Int, Null}]
 
-    dt = DataTable([?Int, ?Float64], [:x1, :x2], 2)
+    dt = DataTable([Union{Int, Null}, Union{Float64, Null}], [:x1, :x2], 2)
     @test size(dt) == (2, 2)
-    @test eltypes(dt) == [?Int, ?Float64]
+    @test eltypes(dt) == [Union{Int, Null}, Union{Float64, Null}]
 
-    @test dt == DataTable([?Int, ?Float64], 2)
+    @test dt == DataTable([Union{Int, Null}, Union{Float64, Null}], 2)
 
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
@@ -75,7 +75,7 @@ module TestConstructors
         answer = [Array{Int,1}, Array{Int,1}, Array{Int,1}]
         @test map(typeof, dt.columns) == answer
         dt[:D] = [4, 5, null]
-        push!(answer, Vector{?Int})
+        push!(answer, Vector{Union{Int, Null}})
         @test map(typeof, dt.columns) == answer
         dt[:E] = 'c'
         push!(answer, Vector{Char})

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,5 +1,5 @@
 module TestConversions
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
     using DataStructures: OrderedDict, SortedDict
 
     dt = DataTable()
@@ -29,17 +29,17 @@ module TestConversions
     @test ai == convert(Matrix{Int}, dt)
 
     @test_throws MethodError dt[1,1] = null
-    dt[:A] = Vector{?Float64}(1.0:5.0)
+    dt[:A] = Vector{Union{Float64, Null}}(1.0:5.0)
     dt[1, 1] = null
-    na = convert(Array{?Float64}, dt)
-    naa = convert(Array{?Any}, dt)
-    nai = convert(Array{?Int}, dt)
-    @test isa(na, Matrix{?Float64})
+    na = convert(Array{Union{Float64, Null}}, dt)
+    naa = convert(Array{Union{Any, Null}}, dt)
+    nai = convert(Array{Union{Int, Null}}, dt)
+    @test isa(na, Matrix{Union{Float64, Null}})
     @test na == convert(Matrix, dt)
-    @test isa(naa, Matrix{?Any})
-    @test naa == convert(Matrix{?Any}, dt)
-    @test isa(nai, Matrix{?Int})
-    @test nai == convert(Matrix{?Int}, dt)
+    @test isa(naa, Matrix{Union{Any, Null}})
+    @test naa == convert(Matrix{Union{Any, Null}}, dt)
+    @test isa(nai, Matrix{Union{Int, Null}})
+    @test nai == convert(Matrix{Union{Int, Null}}, dt)
 
     a = [1.0,2.0]
     b = [-0.1,3]

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,5 +1,5 @@
 module TestData
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
     importall Base # so that we get warnings for conflicts
 
     #test_group("Vector creation")
@@ -82,7 +82,7 @@ module TestData
     N = 20
     #Cast to Int64 as rand() behavior differs between Int32/64
     d1 = rand(map(Int64, 1:2), N)
-    d2 = NullableCategoricalArray(["A", "B", null])[rand(map(Int64, 1:3), N)]
+    d2 = CategoricalArray(["A", "B", null])[rand(map(Int64, 1:3), N)]
     d3 = randn(N)
     d4 = randn(N)
     dt7 = DataTable(Any[d1, d2, d3], [:d1, :d2, :d3])
@@ -109,7 +109,7 @@ module TestData
     @test dt8[1, :d1_sum] == sum(dt7[:d1])
 
     dt8 = aggregate(dt7, :d2, [sum, length], sort=true)
-    @test dt8[1:2, :d2] == NullableCategoricalArray(["A", "B"])
+    @test dt8[1:2, :d2] == CategoricalArray{Union{String, Null}}(["A", "B"])
     @test size(dt8, 1) == 3
     @test size(dt8, 2) == 5
     @test sum(dt8[:d1_length]) == N
@@ -254,7 +254,7 @@ module TestData
     )
 
     dt2 = DataTable(
-        a = Vector{?Symbol}([:x,:y][[1,2,1,1,2]]),
+        a = Vector{Union{Symbol, Null}}([:x,:y][[1,2,1,1,2]]),
         b = [:A,:B,:C][[1,1,1,2,3]],
         v2 = randn(5)
     )
@@ -266,9 +266,9 @@ module TestData
     # m2 = join(dt1, dt2, on = ["a","b"], kind = :outer)
     # @test m2[10,:v2] == null
     # @test m2[:a] ==
-    #               (?String)["x", "x", "y", "y",
-    #                         "x", "x", "x", "x", "x", "y",
-    #                         null, "y"]
+    #               Union{String, Null}["x", "x", "y", "y",
+    #                                   "x", "x", "x", "x", "x", "y",
+    #                                   null, "y"]
 
     srand(1)
     function spltdt(d)

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -1,5 +1,5 @@
 module TestDataTable
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     #
     # Equality
@@ -73,12 +73,12 @@ module TestDataTable
     @test x0[:d] == Int[]
 
     # similar / nulls
-    dt = DataTable(a = (?Int)[1],
-                   b = (?String)["b"],
-                   c = NullableCategoricalArray([3.3]))
+    dt = DataTable(a = Union{Int, Null}[1],
+                   b = Union{String, Null}["b"],
+                   c = CategoricalArray{Union{Float64, Null}}([3.3]))
     nulldt = DataTable(a = nulls(Int, 2),
                        b = nulls(String, 2),
-                       c = NullableCategoricalArray{Float64}(2))
+                       c = CategoricalArray{Union{Float64, Null}}(2))
     @test nulldt == similar(dt, 2)
 
     # Associative methods
@@ -94,7 +94,7 @@ module TestDataTable
     @test isempty(dt.columns)
     @test isempty(dt)
 
-    dt = DataTable(a=(?Int)[1, 2], b=(?Float64)[3.0, 4.0])
+    dt = DataTable(a=Union{Int, Null}[1, 2], b=Union{Float64, Null}[3.0, 4.0])
     @test_throws BoundsError insert!(dt, 5, ["a", "b"], :newcol)
     @test_throws ErrorException insert!(dt, 1, ["a"], :newcol)
     @test insert!(dt, 1, ["a", "b"], :newcol) == dt
@@ -109,46 +109,46 @@ module TestDataTable
     @test dt == DataTable(a=[1, 2], b=["a", "b"], c=[:c, :d])
 
     #test_group("Empty DataTable constructors")
-    dt = DataTable(?Int, 10, 3)
+    dt = DataTable(Union{Int, Null}, 10, 3)
     @test size(dt, 1) == 10
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == Vector{?Int}
-    @test typeof(dt[:, 2]) == Vector{?Int}
-    @test typeof(dt[:, 3]) == Vector{?Int}
+    @test typeof(dt[:, 1]) == Vector{Union{Int, Null}}
+    @test typeof(dt[:, 2]) == Vector{Union{Int, Null}}
+    @test typeof(dt[:, 3]) == Vector{Union{Int, Null}}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
-    dt = DataTable([?Int, ?Float64, ?String], 100)
+    dt = DataTable([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}], 100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == Vector{?Int}
-    @test typeof(dt[:, 2]) == Vector{?Float64}
-    @test typeof(dt[:, 3]) == Vector{?String}
+    @test typeof(dt[:, 1]) == Vector{Union{Int, Null}}
+    @test typeof(dt[:, 2]) == Vector{Union{Float64, Null}}
+    @test typeof(dt[:, 3]) == Vector{Union{String, Null}}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
-    dt = DataTable([?Int, ?Float64, ?String],
+    dt = DataTable([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}],
                    [:A, :B, :C], 100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == Vector{?Int}
-    @test typeof(dt[:, 2]) == Vector{?Float64}
-    @test typeof(dt[:, 3]) == Vector{?String}
+    @test typeof(dt[:, 1]) == Vector{Union{Int, Null}}
+    @test typeof(dt[:, 2]) == Vector{Union{Float64, Null}}
+    @test typeof(dt[:, 3]) == Vector{Union{String, Null}}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
 
     #FIXME: something in CategoricalArrays
-    # dt = DataTable([?Int, ?Float64, ?String],
+    # dt = DataTable([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}],
     #                [:A, :B, :C], [false, false, true],100)
     # @test size(dt, 1) == 100
     # @test size(dt, 2) == 3
-    # @test typeof(dt[:, 1]) == Vector{?Int}
-    # @test typeof(dt[:, 2]) == Vector{?Float64}
-    # @test typeof(dt[:, 3]) == NullableCategoricalVector{String,UInt32}
+    # @test typeof(dt[:, 1]) == Vector{Union{Int, Null}}
+    # @test typeof(dt[:, 2]) == Vector{Union{Float64, Null}}
+    # @test typeof(dt[:, 3]) <: CategoricalVector{Union{String, Null}}
     # @test all(isnull, dt[:, 1])
     # @test all(isnull, dt[:, 2])
     # @test all(isnull, dt[:, 3])
@@ -283,19 +283,19 @@ module TestDataTable
                                     b=["3", null]))
         @test nothing ==
               describe(f, DataTable(a=CategoricalArray([1, 2]),
-                                    b=NullableCategoricalArray(["3", null])))
+                                    b=CategoricalArray(["3", null])))
         @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, CategoricalArray([1, 2, 3]))
         @test nothing == describe(f, Any["1", "2", null])
         @test nothing == describe(f, ["1", "2", null])
-        @test nothing == describe(f, NullableCategoricalArray(["1", "2", null]))
+        @test nothing == describe(f, CategoricalArray(["1", "2", null]))
     end
 
     #Check the output of unstack
-    dt = DataTable(Fish = NullableCategoricalArray(["Bob", "Bob", "Batman", "Batman"]),
-                   Key = (?String)["Mass", "Color", "Mass", "Color"],
-                   Value = (?String)["12 g", "Red", "18 g", "Grey"])
+    dt = DataTable(Fish = CategoricalArray{Union{String, Null}}(["Bob", "Bob", "Batman", "Batman"]),
+                   Key = Union{String, Null}["Mass", "Color", "Mass", "Color"],
+                   Value = Union{String, Null}["12 g", "Red", "18 g", "Grey"])
     # Check that reordering levels does not confuse unstack
     levels!(dt[1], ["XXX", "Bob", "Batman"])
     #Unstack specifying a row column
@@ -304,11 +304,11 @@ module TestDataTable
     #FIXME: categoricalarrays
     # dt3 = unstack(dt, :Key, :Value)
     #The expected output
-    dt4 = DataTable(Fish = (?String)["XXX", "Bob", "Batman"],
-                    Color = (?String)[null, "Red", "Grey"],
-                    Mass = (?String)[null, "12 g", "18 g"])
+    dt4 = DataTable(Fish = Union{String, Null}["XXX", "Bob", "Batman"],
+                    Color = Union{String, Null}[null, "Red", "Grey"],
+                    Mass = Union{String, Null}[null, "12 g", "18 g"])
     @test dt2 == dt4
-    @test typeof(dt2[:Fish]) <: NullableCategoricalArray{String,1,UInt32}
+    @test typeof(dt2[:Fish]) <: CategoricalVector{Union{String, Null}}
     # first column stays as CategoricalArray in dt3
     # @test dt3[:, 2:3] == dt4[2:3, 2:3]
     #Make sure unstack works with NULLs at the start of the value column
@@ -338,7 +338,7 @@ module TestDataTable
         @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
         @test udt == DataTable(Any[[1, 2], [1, 5], [2, 6],
                                    [3, 7], [4, 8]], [:id, :a, :b, :c, :d])
-        @test all(typeof.(udt.columns) .== Vector{?Int})
+        @test all(isa.(udt.columns, Vector{Union{Int, Null}}))
         dt = DataTable(Any[categorical(repeat(1:2, inner=4)),
                            categorical(repeat('a':'d', outer=2)), categorical(1:8)],
                        [:id, :variable, :value])
@@ -346,11 +346,11 @@ module TestDataTable
         # @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
         @test udt == DataTable(Any[[1, 2], [1, 5], [2, 6],
                                    [3, 7], [4, 8]], [:id, :a, :b, :c, :d])
-        @test all(typeof.(udt.columns) .== NullableCategoricalVector{Int, UInt32})
+        @test all(isa.(udt.columns, CategoricalVector{Union{Int, Null}}))
     end
 
     @testset "duplicate entries in unstack warnings" begin
-        dt = DataTable(id=(?Int)[1, 2, 1, 2], variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
+        dt = DataTable(id=Union{Int, Null}[1, 2, 1, 2], variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
         @static if VERSION >= v"0.6.0-dev.1980"
             @test_warn "Duplicate entries in unstack." unstack(dt, :id, :variable, :value)
             @test_warn "Duplicate entries in unstack at row 3." unstack(dt, :variable, :value)
@@ -407,11 +407,11 @@ module TestDataTable
 
     @testset "column conversions" begin
         dt = DataTable(Any[collect(1:10), collect(1:10)])
-        @test !isa(dt[1], Vector{?Int})
+        @test !isa(dt[1], Vector{Union{Int, Null}})
         nullable!(dt, 1)
-        @test isa(dt[1], Vector{?Int})
-        @test !isa(dt[2], Vector{?Int})
+        @test isa(dt[1], Vector{Union{Int, Null}})
+        @test !isa(dt[2], Vector{Union{Int, Null}})
         nullable!(dt, [1,2])
-        @test isa(dt[1], Vector{?Int}) && isa(dt[2], Vector{?Int})
+        @test isa(dt[1], Vector{Union{Int, Null}}) && isa(dt[2], Vector{Union{Int, Null}})
     end
 end

--- a/test/datatablerow.jl
+++ b/test/datatablerow.jl
@@ -1,10 +1,10 @@
 module TestDataTableRow
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dt = DataTable(a=[1,   2,   3,   1,   2,   2 ],
                    b=[2.0, null, 1.2, 2.0, null, null],
                    c=["A", "B", "C", "A", "B", null],
-                   d=NullableCategoricalArray([:A,  null,  :C,  :A, null,  :C]))
+                   d=CategoricalArray([:A,  null,  :C,  :A, null,  :C]))
     dt2 = DataTable(a = [1, 2, 3])
 
     #

--- a/test/duplicates.jl
+++ b/test/duplicates.jl
@@ -1,5 +1,5 @@
 module TestDuplicates
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dt = DataTable(a = [1, 2, 3, 3, 4])
     udt = DataTable(a = [1, 2, 3, 4])
@@ -8,10 +8,10 @@ module TestDuplicates
     unique!(dt)
     @test dt == udt
 
-    pdt = DataTable(a = NullableCategoricalArray(["a", "a", null, null, "b", null, "a", null]),
-                    b = NullableCategoricalArray(["a", "b", null, null, "b", "a", "a", "a"]))
-    updt = DataTable(a = NullableCategoricalArray(["a", "a", null, "b", null]),
-                     b = NullableCategoricalArray(["a", "b", null, "b", "a"]))
+    pdt = DataTable(a = CategoricalArray(["a", "a", null, null, "b", null, "a", null]),
+                    b = CategoricalArray(["a", "b", null, null, "b", "a", "a", "a"]))
+    updt = DataTable(a = CategoricalArray(["a", "a", null, "b", null]),
+                     b = CategoricalArray(["a", "b", null, "b", "a"]))
     @test nonunique(pdt) == [false, false, false, true, false, false, true, true]
     @test nonunique(updt) == falses(5)
     @test updt == unique(pdt)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1,12 +1,12 @@
 module TestGrouping
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     srand(1)
     dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
                    b = repeat([2, 1], outer=[4]),
                    c = randn(8))
-    #dt[6, :a] = Nullable()
-    #dt[7, :b] = Nullable()
+    #dt[6, :a] = null
+    #dt[7, :b] = null
 
     nullfree = DataTable(Any[collect(1:10)], [:x1])
     @testset "colwise" begin
@@ -42,9 +42,9 @@ module TestGrouping
             @test size(cw) == (length([sum, minimum]), ncol(nullfree))
             @test cw == answer
 
-            cw = colwise([Vector{?Int}], nullfree)
-            answer = reshape([Vector{?Int}(1:10)], (1,1))
-            @test isa(cw, Array{Vector{?Int},2})
+            cw = colwise([Vector{Union{Int, Null}}], nullfree)
+            answer = reshape([Vector{Union{Int, Null}}(1:10)], (1,1))
+            @test isa(cw, Array{Vector{Union{Int, Null}},2})
             @test size(cw) == (1, ncol(nullfree))
             @test cw == answer
 
@@ -69,8 +69,8 @@ module TestGrouping
             @test size(cw) == (length((sum, length)), ncol(nullfree))
             @test cw == answer
 
-            cw = colwise((CategoricalArray, Vector{?Int}), nullfree)
-            answer = reshape([CategoricalArray(1:10), Vector{?Int}(1:10)],
+            cw = colwise((CategoricalArray, Vector{Union{Int, Null}}), nullfree)
+            answer = reshape([CategoricalArray(1:10), Vector{Union{Int, Null}}(1:10)],
                              (2, ncol(nullfree)))
             @test typeof(cw) == Array{AbstractVector,2}
             @test size(cw) == (2, ncol(nullfree))

--- a/test/index.jl
+++ b/test/index.jl
@@ -1,5 +1,5 @@
 module TestIndex
-using Base.Test, DataTables, Nulls, DataTables.Index
+using Base.Test, DataTables, DataTables.Index
 
 i = Index()
 push!(i, :A)
@@ -15,10 +15,10 @@ inds = Any[1,
            1:1,
            1.0:1.0,
            [:A],
-           (?Bool)[true],
-           (?Int)[1],
-           (?Float64)[1.0],
-           (?Symbol)[:A]]
+           Union{Bool, Null}[true],
+           Union{Int, Null}[1],
+           Union{Float64, Null}[1.0],
+           Union{Symbol, Null}[:A]]
 
 for ind in inds
     if ind == :A || ndims(ind) == 0

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,5 +1,5 @@
 module TestIO
-    using Base.Test, DataTables, Nulls, CategoricalArrays
+    using Base.Test, DataTables, CategoricalArrays
     using LaTeXStrings
 
     # Test LaTeX export
@@ -41,13 +41,19 @@ module TestIO
                    B = 'a':'c',
                    C = ["A", "B", "C"],
                    D = CategoricalArray('a':'c'),
-                   E = NullableCategoricalArray(["A", "B", "C"]),
-                   E = Vector{?Int}(1:3),
-                   F = nulls(3),
-                   G = fill(null, 3))
+                   E = CategoricalArray(["A", "B", null]),
+                   F = Vector{Union{Int, Null}}(1:3),
+                   G = nulls(3),
+                   H = fill(null, 3))
 
-    answer = Sys.WORD_SIZE == 64 ? 0x3bd4a4a099ae8aac : 0x5ecdc4bb
-    @test hash(sprint(printtable, dt)) == answer
+    DRT = CategoricalArrays.DefaultRefType
+    @test sprint(printtable, dt) ==
+        """
+        "A","B","C","D","E","F","G","H"
+        1,"a","A","CategoricalArrays.CategoricalValue{Char,$DRT} 'a'","CategoricalArrays.CategoricalValue{String,$DRT} "A"","1",null,null
+        2,"b","B","CategoricalArrays.CategoricalValue{Char,$DRT} 'b'","CategoricalArrays.CategoricalValue{String,$DRT} "B"","2",null,null
+        3,"c","C","CategoricalArrays.CategoricalValue{Char,$DRT} 'c'",null,"3",null,null
+        """
 
     # DataStreams
     # using CSV

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -1,5 +1,5 @@
 module TestIteration
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dv = [1, 2, null]
     dm = [1 2; 3 4]

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,5 +1,5 @@
 module TestShow
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dt = DataTable(A = 1:3, B = ["x", "y", "z"])
 

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -1,10 +1,10 @@
 module TestSort
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dv1 = [9, 1, 8, null, 3, 3, 7, null]
     dv2 = [9, 1, 8, null, 3, 3, 7, null]
-    dv3 = Vector{?Int}(1:8)
-    cv1 = NullableCategoricalArray(dv1, ordered=true)
+    dv3 = Vector{Union{Int, Null}}(1:8)
+    cv1 = CategoricalArray(dv1, ordered=true)
 
     d = DataTable(dv1 = dv1, dv2 = dv2, dv3 = dv3, cv1 = cv1)
 

--- a/test/subdatatable.jl
+++ b/test/subdatatable.jl
@@ -1,5 +1,5 @@
 module TestSubDataTable
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     @testset "view -- DataTable" begin
         dt = DataTable(x = 1:10, y = 1.0:10.0)
@@ -32,10 +32,10 @@ module TestSubDataTable
         @test view(dt, Integer[1, 2]) == head(dt, 2)
         @test view(dt, UInt[1, 2]) == head(dt, 2)
         @test view(dt, BigInt[1, 2]) == head(dt, 2)
-        @test view(dt, (?Int)[1, 2]) == head(dt, 2)
-        @test view(dt, (?Integer)[1, 2]) == head(dt, 2)
-        @test view(dt, (?UInt)[1, 2]) == head(dt, 2)
-        @test view(dt, (?BigInt)[1, 2]) == head(dt, 2)
+        @test view(dt, Union{Int, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{Integer, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{UInt, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{BigInt, Null}[1, 2]) == head(dt, 2)
         @test_throws NullException view(dt, [null, 1])
     end
 
@@ -70,10 +70,10 @@ module TestSubDataTable
         @test view(dt, Integer[1, 2]) == head(dt, 2)
         @test view(dt, UInt[1, 2]) == head(dt, 2)
         @test view(dt, BigInt[1, 2]) == head(dt, 2)
-        @test view(dt, (?Int)[1, 2]) == head(dt, 2)
-        @test view(dt, (?Integer)[1, 2]) == head(dt, 2)
-        @test view(dt, (?UInt)[1, 2]) == head(dt, 2)
-        @test view(dt, (?BigInt)[1, 2]) == head(dt, 2)
+        @test view(dt, Union{Int, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{Integer, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{UInt, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{BigInt, Null}[1, 2]) == head(dt, 2)
         @test_throws NullException view(dt, [null, 1])
     end
 end


### PR DESCRIPTION
Batch/Row -> Field/Column
Update CategoricalArray tests
remove references to Nullables and NullableArrays
Add check for whether Base.unique! is defined (0.6 vs. 0.7)
Update StatsBase.describe code to work with Nulls
Update documentation and examples for working with nulls

This is passing for me locally using @nalimilan's https://github.com/JuliaData/CategoricalArrays.jl/pull/70 and @quinnj's [null branch on DataStreams](https://github.com/JuliaData/DataStreams.jl/tree/jq/gangy). Note this PR is targetted to merge into @quinnj's branch under review in #66 rather than master so we don't lose track of the things we haven't addressed yet in that PR