### PR TITLE
Add upper limit on CategoricalArrays version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.5
 NullableArrays 0.1.1
-CategoricalArrays 0.1.2
+CategoricalArrays 0.1.2 0.2.0
 StatsBase 0.11.0
 SortingAlgorithms
 Reexport


### PR DESCRIPTION
Next major release of CategoricalArrays will move from `Nullable` to `Union{T, Null}` and will not work with the package in its current state.

This PR will allow tagging a non-breaking release of DataTables before tagging a breaking CategoricalArrays release. This will be especially useful if #66 is never merged in DataTables and goes directly to DataFrames (since there's no point in breaking DataTables to make it identical to DataFrames).