### PR TITLE
Remove exported macros that no longer exist

### DIFF
--- a/src/DataTables.jl
+++ b/src/DataTables.jl
@@ -25,13 +25,7 @@ import Base: ==, |>
 ##
 ##############################################################################
 
-export @~,
-       @csv_str,
-       @csv2_str,
-       @tsv_str,
-       @wsv_str,
-
-       AbstractDataTable,
+export AbstractDataTable,
        DataTable,
        DataTableRow,
        GroupApplied,


### PR DESCRIPTION
I think we missed the @~ in https://github.com/JuliaData/DataTables.jl/pull/15 and I missed the readtable macros in https://github.com/JuliaData/DataTables.jl/pull/26