### PR TITLE
Add upper limit on DataStreams and WeakRefStrings version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,5 +5,5 @@ StatsBase 0.11.0
 SortingAlgorithms
 Reexport
 Compat 0.19.0
-WeakRefStrings 0.1.3
-DataStreams 0.1.0
+WeakRefStrings 0.1.3 0.3.0
+DataStreams 0.1.0 0.2.0


### PR DESCRIPTION
Next major releases of DataStreams and WeakRefStrings will move from `Nullable` to `Union{T, Null}` and will not work with the package in its current state.

Cf. https://github.com/JuliaLang/METADATA.jl/pull/10915.