### PR TITLE
PR 66 rebased onto master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 
 language: julia
 julia:
-  - 0.5
   - 0.6
   - nightly
 os:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,10 @@
-julia 0.6-
-Nulls 0.0.1
-CategoricalArrays 0.1.2
+julia 0.6
+Nulls 0.0.6
+CategoricalArrays 0.2.0
 StatsBase 0.11.0
 SortingAlgorithms
 Reexport
 Compat 0.19.0
-WeakRefStrings 0.1.3 0.3.0
-DataStreams 0.1.0 0.2.0
+WeakRefStrings 0.3.0
+DataStreams 0.2.0
+CSV 0.2.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
-julia 0.5
-NullableArrays 0.1.1
-CategoricalArrays 0.1.2 0.2.0
+julia 0.6-
+Nulls 0.0.1
+CategoricalArrays 0.1.2
 StatsBase 0.11.0
 SortingAlgorithms
 Reexport

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/docs/src/man/categorical.md
+++ b/docs/src/man/categorical.md
@@ -7,14 +7,20 @@ v = ["Group A", "Group A", "Group A",
      "Group B", "Group B", "Group B"]
 ```
 
-The naive encoding used in an `Array` or in a `NullableArray` represents every entry of this vector as a full string. In contrast, we can represent the data more efficiently by replacing the strings with indices into a small pool of levels. This is what the `CategoricalArray` type does:
+The naive encoding used in an `Array` represents every entry of this vector as a full string. In contrast, we can represent the data more efficiently by replacing the strings with indices into a small pool of levels. This is what the `CategoricalArray` type does:
 
 ```julia
 cv = CategoricalArray(["Group A", "Group A", "Group A",
                        "Group B", "Group B", "Group B"])
 ```
 
-A companion type, `NullableCategoricalArray`, allows storing missing values in the array: is to `CategoricalArray` what `NullableArray` is to the standard `Array` type.
+`CategoricalArrays` support missing values via the `Nulls` package.
+
+```julia
+using Nulls
+cv = CategoricalArray(["Group A", null, "Group A",
+                       "Group B", "Group B", null])
+```
 
 In addition to representing repeated data efficiently, the `CategoricalArray` type allows us to determine efficiently the allowed levels of the variable at any time using the `levels` function (note that levels may or may not be actually used in the data):
 
@@ -30,7 +36,7 @@ By default, a `CategoricalArray` is able to represent 2<sup>32</sup>differents l
 cv = compact(cv)
 ```
 
-Often, you will have factors encoded inside a DataTable with `Array` or `NullableArray` columns instead of `CategoricalArray` or `NullableCategoricalArray` columns. You can do conversion of a single column using the `categorical` function:
+Often, you will have factors encoded inside a DataTable with `Array` columns instead of `CategoricalArray` columns. You can do conversion of a single column using the `categorical` function:
 
 ```julia
 cv = categorical(v)
@@ -44,6 +50,6 @@ dt = DataTable(A = [1, 1, 1, 2, 2, 2],
 categorical!(dt, [:A, :B])
 ```
 
-Using categorical arrays is important for working with the [GLM package](https://github.com/JuliaStats/GLM.jl). When fitting regression models, `CategoricalArray` and `NullableCategoricalArray` columns in the input are translated into 0/1 indicator columns in the `ModelMatrix` with one column for each of the levels of the `CategoricalArray`/`NullableCategoricalArray`. This allows one to analyze categorical data efficiently.
+Using categorical arrays is important for working with the [GLM package](https://github.com/JuliaStats/GLM.jl). When fitting regression models, `CategoricalArray` columns in the input are translated into 0/1 indicator columns in the `ModelMatrix` with one column for each of the levels of the `CategoricalArray`. This allows one to analyze categorical data efficiently.
 
-See the [CategoricalArrays package](https://github.com/nalimilan/CategoricalArrays.jl) for more information regarding categorical arrays.
+See the [CategoricalArrays package](https://github.com/JuliaData/CategoricalArrays.jl) for more information regarding categorical arrays.

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -31,10 +31,10 @@ julia> x = [1, 2, null]
 julia> eltype(x)
 Union{Nulls.Null, Int64}
 
-julia> Union{Int, Null}
+julia> Union{Null, Int}
 Union{Nulls.Null, Int64}
 
-julia> eltype(x) == Union{Int, Null}
+julia> eltype(x) == Union{Null, Int}
 true
 
 ```

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -2,88 +2,109 @@
 
 ## Installation
 
-The DataTables package is available through the Julia package system. Throughout the rest of this tutorial, we will assume that you have installed the DataTables package and have already typed `using NullableArrays, DataTables` to bring all of the relevant variables into your current namespace. In addition, we will make use of the `RDatasets` package, which provides access to hundreds of classical data sets.
+The DataTables package is available through the Julia package system. Throughout the rest of this tutorial, we will assume that you have installed the DataTables package and have already typed `using DataTables` to bring all of the relevant variables into your current namespace.
 
-## The `Nullable` Type
+## The `Null` Type
 
-To get started, let's examine the `Nullable` type. Objects of this type can either hold a value, or represent a missing value (`null`). For example, this is a `Nullable` holding the integer `1`:
-
-```julia
-Nullable(1)
-```
-
-And this represents a missing value:
-```julia
-Nullable()
-```
-
-`Nullable` objects support all standard operators, which return another `Nullable`. One of the essential properties of `null` values is that they poison other items. To see this, try to add something like `Nullable(1)` to `Nullable()`:
+To get started, let's examine the `Null` type. `Null` is a type implemented by [Nulls.jl](https://github.com/JuliaData/Nulls.jl) to represent missing data. `null` is an instance of the type `Null` used to represent a missing value.
 
 ```julia
-Nullable(1) + Nullable()
+julia> using DataTables
+
+julia> null
+null
+
+julia> typeof(null)
+Nulls.Null
+
 ```
 
-The `get` function can be used to extract the value from the [`Nullable`](http://docs.julialang.org/en/stable/manual/types/#nullable-types-representing-missing-values) wrapper when it is not null. For example:
+The `Null` type lets users create `Vector`s and `DataTable` columns with missing values. Here we create a vector with a null value and the element-type of the returned vector is `Union{Nulls.Null, Int64}`.
 
 ```julia
-julia> a = Nullable("14:00:00")
-Nullable{String}("14:00:00")
+julia> x = [1, 2, null]
+3-element Array{Union{Nulls.Null, Int64},1}:
+ 1
+ 2
+  null
 
-julia> b = get(a)
-"14:00:00"
+julia> eltype(x)
+Union{Nulls.Null, Int64}
 
-julia> typeof(b)
-String
+julia> Union{Int, Null}
+Union{Nulls.Null, Int64}
+
+julia> eltype(x) == Union{Int, Null}
+true
+
 ```
 
-Note that operations mixing `Nullable` and scalars (e.g. `1 + Nullable(1)`) are not supported.
-
-## The `NullableArray` Type
-
-`Nullable` objects can be stored in a standard `Array` just like any value:
+`null` values can be excluded when performing operations by using `Nulls.skip`, which returns a memory-efficient iterator.
 
 ```julia
-v = Nullable{Int}[1, 3, 4, 5, 4]
+julia> Nulls.skip(x)
+Base.Generator{Base.Iterators.Filter{Nulls.##4#6{Nulls.Null},Array{Union{Nulls.Null, Int64},1}},Nulls.##3#5}(Nulls.#3, Base.Iterators.Filter{Nulls.##4#6{Nulls.Null},Array{Union{Nulls.Null, Int64},1}}(Nulls.#4, Union{Nulls.Null, Int64}[1, 2, null]))
+
 ```
 
-But arrays of `Nullable` are inefficient, both in terms of computation costs and of memory use. `NullableArrays` provide a more efficient storage, and behave like `Array{Nullable}` objects.
+The output of `Nulls.skip` can be passed directly into functions as an argument. For example, we can find the `sum` of all non-null values or `collect` the non-null values into a new null-free vector.
 
 ```julia
-nv = NullableArray(Nullable{Int}[Nullable(), 3, 2, 5, 4])
+julia> sum(Nulls.skip(x))
+3
+
+julia> collect(Nulls.skip(x))
+2-element Array{Int64,1}:
+ 1
+ 2
+
 ```
 
-In many cases we're willing to just ignore missing values and remove them from our vector. We can do that using the `dropnull` function:
+`null` elements can be replaced with other values via `Nulls.replace`.
 
 ```julia
-dropnull(nv)
-mean(dropnull(nv))
+julia> collect(Nulls.replace(x, 1))
+3-element Array{Int64,1}:
+ 1
+ 2
+ 1
+
 ```
 
-Instead of removing `null` values, you can try to convert the `NullableArray` into a normal Julia `Array` using `convert`:
+The function `Nulls.T` returns the element-type `T` in `Union{T, Null}`.
 
 ```julia
-convert(Array, nv)
+julia> Nulls.T(eltype(x))
+Int64
+
 ```
 
-This fails in the presence of `null` values, but will succeed if there are no `null` values:
+Use `nulls` to generate nullable `Vector`s and `Array`s, using the optional first argument to specify the element-type.
 
 ```julia
-nv[1] = 3
-convert(Array, nv)
+julia> nulls(1)
+1-element Array{Nulls.Null,1}:
+ null
+
+julia> nulls(3)
+3-element Array{Nulls.Null,1}:
+ null
+ null
+ null
+
+julia> nulls(1, 3)
+1×3 Array{Nulls.Null,2}:
+ null  null  null
+
+julia> nulls(Int, 1, 3)
+1×3 Array{Union{Nulls.Null, Int64},2}:
+ null  null  null
+
 ```
-
-In addition to removing `null` values and hoping they won't occur, you can also replace any `null` values using the `convert` function, which takes a replacement value as an argument:
-
-```julia
-nv = NullableArray(Nullable{Int}[Nullable(), 3, 2, 5, 4])
-mean(convert(Array, nv, 0))
-```
-
-Which strategy for dealing with `null` values is most appropriate will typically depend on the specific details of your data analysis pathway.
 
 ## The `DataTable` Type
 
-The `DataTable` type can be used to represent data tables, each column of which is an array (by default, a `NullableArray`). You can specify the columns using keyword arguments:
+The `DataTable` type can be used to represent data tables, each column of which is a vector. You can specify the columns using keyword arguments:
 
 ```julia
 dt = DataTable(A = 1:4, B = ["M", "F", "F", "M"])
@@ -123,22 +144,22 @@ describe(dt)
 To focus our search, we start looking at just the means and medians of specific columns. In the example below, we use numeric indexing to access the columns of the `DataTable`:
 
 ```julia
-mean(dropnull(dt[1]))
-median(dropnull(dt[1]))
+mean(Nulls.skip(dt[1]))
+median(Nulls.skip(dt[1]))
 ```
 
 We could also have used column names to access individual columns:
 
 ```julia
-mean(dropnull(dt[:A]))
-median(dropnull(dt[:A]))
+mean(Nulls.skip(dt[:A]))
+median(Nulls.skip(dt[:A]))
 ```
 
 We can also apply a function to each column of a `DataTable` with the `colwise` function. For example:
 
 ```julia
 dt = DataTable(A = 1:4, B = randn(4))
-colwise(c->cumsum(dropnull(c)), dt)
+colwise(c->cumsum(Nulls.skip(c)), dt)
 ```
 
 ## Importing and Exporting Data (I/O)
@@ -178,9 +199,7 @@ For more information, use the REPL [help-mode](http://docs.julialang.org/en/stab
 
 ## Accessing Classic Data Sets
 
-To see more of the functionality for working with `DataTable` objects, we need a more complex data set to work with. We'll use the `RDatasets` package, which provides access to many of the classical data sets that are available in R.
-
-For example, we can access Fisher's iris data set using the following functions:
+To see more of the functionality for working with `DataTable` objects, we need a more complex data set to work with. We can access Fisher's iris data set using the following functions:
 
 ```julia
 using CSV

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -80,6 +80,6 @@ None of these reshaping functions perform any aggregation. To do aggregation, us
 
 ```julia
 d = stack(iris)
-x = by(d, [:variable, :Species], dt -> DataTable(vsum = mean(dropnull(dt[:value]))))
+x = by(d, [:variable, :Species], dt -> DataTable(vsum = mean(Nulls.skip(dt[:value]))))
 unstack(x, :Species, :vsum)
 ```

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -12,7 +12,7 @@ using CSV
 iris = CSV.read(joinpath(Pkg.dir("DataTables"), "test/data/iris.csv"), DataTable)
 
 by(iris, :Species, size)
-by(iris, :Species, dt -> mean(dropnull(dt[:PetalLength])))
+by(iris, :Species, dt -> mean(Nulls.skip(dt[:PetalLength])))
 by(iris, :Species, dt -> DataTable(N = size(dt, 1)))
 ```
 
@@ -20,7 +20,7 @@ The `by` function also support the `do` block form:
 
 ```julia
 by(iris, :Species) do dt
-   DataTable(m = mean(dropnull(dt[:PetalLength])), s² = var(dropnull(dt[:PetalLength])))
+   DataTable(m = mean(Nulls.skip(dt[:PetalLength])), s² = var(Nulls.skip(dt[:PetalLength])))
 end
 ```
 
@@ -30,7 +30,7 @@ We show several examples of the `aggregate` function applied to the `iris` datas
 
 ```julia
 aggregate(iris, :Species, sum)
-aggregate(iris, :Species, [sum, x->mean(dropnull(x))])
+aggregate(iris, :Species, [sum, x->mean(Nulls.skip(x))])
 ```
 
 If you only want to split the data set into subsets, use the `groupby` function:

--- a/docs/src/man/subsets.md
+++ b/docs/src/man/subsets.md
@@ -25,7 +25,7 @@ Referring to the first column by index or name:
 
 ```julia
 julia> dt[1]
-10-element NullableArrays.NullableArray{Int64,1}:
+10-element Array{Int64,1}:
   1
   2
   3
@@ -38,7 +38,7 @@ julia> dt[1]
  10
 
 julia> dt[:A]
-10-element NullableArrays.NullableArray{Int64,1}:
+10-element Array{Int64,1}:
   1
   2
   3
@@ -55,10 +55,10 @@ Refering to the first element of the first column:
 
 ```julia
 julia> dt[1, 1]
-Nullable{Int64}(1)
+1
 
 julia> dt[1, :A]
-Nullable{Int64}(1)
+1
 ```
 
 Selecting a subset of rows by index and an (ordered) subset of columns by name:

--- a/src/DataTables.jl
+++ b/src/DataTables.jl
@@ -8,14 +8,10 @@ module DataTables
 ##
 ##############################################################################
 
-using Compat
-import Compat.String
-using Reexport
-using StatsBase
-import NullableArrays: dropnull, dropnull!
-@reexport using NullableArrays
+using Compat, Reexport
+using StatsBase, SortingAlgorithms, Nulls
 @reexport using CategoricalArrays
-using SortingAlgorithms
+
 using Base: Sort, Order
 import Base: ==, |>
 

--- a/src/DataTables.jl
+++ b/src/DataTables.jl
@@ -8,9 +8,8 @@ module DataTables
 ##
 ##############################################################################
 
-using Compat, Reexport
-using StatsBase, SortingAlgorithms, Nulls
-@reexport using CategoricalArrays
+using Compat, Reexport, StatsBase, SortingAlgorithms
+@reexport using CategoricalArrays, Nulls
 
 using Base: Sort, Order
 import Base: ==, |>

--- a/src/abstractdatatable/abstractdatatable.jl
+++ b/src/abstractdatatable/abstractdatatable.jl
@@ -24,7 +24,6 @@ The following are normally implemented for AbstractDataTables:
 * [`head`](@ref) : first `n` rows
 * [`tail`](@ref) : last `n` rows
 * `convert` : convert to an array
-* `NullableArray` : convert to a NullableArray
 * [`completecases`](@ref) : boolean vector of complete cases (rows with no nulls)
 * [`dropnull`](@ref) : remove rows with null values
 * [`dropnull!`](@ref) : remove rows with null values in-place
@@ -379,6 +378,22 @@ function StatsBase.describe(io, dt::AbstractDataTable)
     end
 end
 
+function StatsBase.describe{T}(io::IO, X::AbstractVector{Union{T, Null}})
+    nullcount = count(isnull, X)
+    pnull = 100 * nullcount/length(X)
+    if pnull != 100 && T <: Real
+        show(io, StatsBase.summarystats(collect(Nulls.skip(X))))
+    else
+        println(io, "Summary Stats:")
+    end
+    println(io, "Length:         $(length(X))")
+    println(io, "Type:           $(eltype(X))")
+    !(T <: Real) && println(io, "Number Unique:  $(length(unique(X)))")
+    println(io, "Number Missing: $(nullcount)")
+    @printf(io, "%% Missing:      %.6f\n", pnull)
+    return
+end
+
 ##############################################################################
 ##
 ## Miscellaneous
@@ -391,7 +406,7 @@ function _nonnull!(res, col)
     end
 end
 
-function _nonnull!(res, col::NullableCategoricalArray)
+function _nonnull!(res, col::CategoricalArray{>: Null})
     for (i, el) in enumerate(col.refs)
         res[i] &= el > 0
     end
@@ -418,9 +433,11 @@ See also [`dropnull`](@ref) and [`dropnull!`](@ref).
 **Examples**
 
 ```julia
-dt = DataTable(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10))
-dt[[1,4,5], :x] = Nullable()
-dt[[9,10], :y] = Nullable()
+dt = DataTable(i = 1:10,
+               x = Vector{Union{Null, Float64}}(rand(10)),
+               y = Vector{Union{Null, String}}(rand(["a", "b", "c"], 10)))
+dt[[1,4,5], :x] = null
+dt[[9,10], :y] = null
 completecases(dt)
 ```
 
@@ -453,9 +470,11 @@ See also [`completecases`](@ref) and [`dropnull!`](@ref).
 **Examples**
 
 ```julia
-dt = DataTable(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10))
-dt[[1,4,5], :x] = Nullable()
-dt[[9,10], :y] = Nullable()
+dt = DataTable(i = 1:10,
+               x = Vector{Union{Null, Float64}}(rand(10)),
+               y = Vector{Union{Null, String}}(rand(["a", "b", "c"], 10)))
+dt[[1,4,5], :x] = null
+dt[[9,10], :y] = null
 dropnull(dt)
 ```
 
@@ -482,9 +501,11 @@ See also [`dropnull`](@ref) and [`completecases`](@ref).
 **Examples**
 
 ```julia
-dt = DataTable(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10))
-dt[[1,4,5], :x] = Nullable()
-dt[[9,10], :y] = Nullable()
+dt = DataTable(i = 1:10,
+               x = Vector{Union{Null, Float64}}(rand(10)),
+               y = Vector{Union{Null, String}}(rand(["a", "b", "c"], 10)))
+dt[[1,4,5], :x] = null
+dt[[9,10], :y] = null
 dropnull!(dt)
 ```
 
@@ -557,7 +578,7 @@ end
 nonunique(dt::AbstractDataTable, cols::Union{Real, Symbol}) = nonunique(dt[[cols]])
 nonunique(dt::AbstractDataTable, cols::Any) = nonunique(dt[cols])
 
-if isdefined(Base, :unique!) # Julia >= 0.7
+if isdefined(:unique!)
     import Base.unique!
 end
 
@@ -629,7 +650,7 @@ without(dt::AbstractDataTable, c::Any) = without(dt, index(dt)[c])
 ##############################################################################
 
 # hcat's first argument must be an AbstractDataTable
-# Trailing arguments (currently) may also be NullableVectors, Vectors, or scalars.
+# Trailing arguments (currently) may also be vectors or scalars.
 
 # hcat! is defined in datatables/datatables.jl
 # Its first argument (currently) must be a DataTable.
@@ -647,13 +668,13 @@ Base.hcat(dt1::AbstractDataTable, dt2::AbstractDataTable, dtn::AbstractDataTable
         T = T.parameters[1]
     end
     if any(col -> eltype(col) >: Null, cols)
-        if any(col -> col <: Union{AbstractCategoricalArray, AbstractNullableCategoricalArray}, cols)
-            return :(NullableCategoricalVector{$T})
+        if any(col -> col <: AbstractCategoricalArray, cols)
+            return :(CategoricalVector{Union{$T, Null}})
         else
-            return :(Vector{?($T)})
+            return :(Vector{Union{$T, Null}})
         end
     else
-        if any(col -> col <: Union{AbstractCategoricalArray, AbstractNullableCategoricalArray}, cols)
+        if any(col -> col <: AbstractCategoricalArray, cols)
             return :(CategoricalVector{$T})
         else
             return :(Vector{$T})

--- a/src/abstractdatatable/abstractdatatable.jl
+++ b/src/abstractdatatable/abstractdatatable.jl
@@ -401,7 +401,7 @@ end
 ##############################################################################
 
 function _nonnull!(res, col)
-    for (i, el) in enumerate(col)
+    @inbounds for (i, el) in enumerate(col)
         res[i] &= !isnull(el)
     end
 end
@@ -663,7 +663,7 @@ Base.hcat(dt::AbstractDataTable, x, y...) = hcat!(hcat(dt, x), y...)
 Base.hcat(dt1::AbstractDataTable, dt2::AbstractDataTable, dtn::AbstractDataTable...) = hcat!(hcat(dt1, dt2), dtn...)
 
 @generated function promote_col_type(cols::AbstractVector...)
-    T = promote_type(map(x-> eltype(x) >: Null ? Nulls.T(eltype(x)) : eltype(x), cols)...)
+    T = promote_type(map(x -> Nulls.T(eltype(x)), cols)...)
     if T <: CategoricalValue
         T = T.parameters[1]
     end

--- a/src/abstractdatatable/abstractdatatable.jl
+++ b/src/abstractdatatable/abstractdatatable.jl
@@ -170,10 +170,10 @@ rename(f::Function, dt::AbstractDataTable)
 
 ```julia
 dt = DataTable(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10))
-rename(x -> @compat(Symbol)(uppercase(string(x))), dt)
-rename(dt, @compat(Dict(:i=>:A, :x=>:X)))
+rename(x -> Symbol(uppercase(string(x))), dt)
+rename(dt, Dict(:i=>:A, :x=>:X))
 rename(dt, :y, :Y)
-rename!(dt, @compat(Dict(:i=>:A, :x=>:X)))
+rename!(dt, Dict(:i=>:A, :x=>:X))
 ```
 
 """
@@ -646,11 +646,11 @@ Base.hcat(dt1::AbstractDataTable, dt2::AbstractDataTable, dtn::AbstractDataTable
     if T <: CategoricalValue
         T = T.parameters[1]
     end
-    if any(col -> Null <: eltype(col), cols)
+    if any(col -> eltype(col) >: Null, cols)
         if any(col -> col <: Union{AbstractCategoricalArray, AbstractNullableCategoricalArray}, cols)
             return :(NullableCategoricalVector{$T})
         else
-            return :(Vector{$T})
+            return :(Vector{?($T)})
         end
     else
         if any(col -> col <: Union{AbstractCategoricalArray, AbstractNullableCategoricalArray}, cols)
@@ -744,7 +744,7 @@ function Base.hash(dt::AbstractDataTable)
     for i in 1:size(dt, 2)
         h = hash(dt[i], h)
     end
-    return @compat UInt(h)
+    return UInt(h)
 end
 
 

--- a/src/abstractdatatable/abstractdatatable.jl
+++ b/src/abstractdatatable/abstractdatatable.jl
@@ -236,7 +236,7 @@ Base.similar(dt::AbstractDataTable, dims::Int) =
 ##############################################################################
 
 # Imported in DataTables.jl for compatibility across Julia 0.4 and 0.5
-@compat(Base.:(==))(dt1::AbstractDataTable, dt2::AbstractDataTable) = isequal(dt1, dt2)
+Base.:(==)(dt1::AbstractDataTable, dt2::AbstractDataTable) = isequal(dt1, dt2)
 
 function Base.isequal(dt1::AbstractDataTable, dt2::AbstractDataTable)
     size(dt1, 2) == size(dt2, 2) || return false

--- a/src/abstractdatatable/io.jl
+++ b/src/abstractdatatable/io.jl
@@ -199,9 +199,9 @@ importall DataStreams
 using WeakRefStrings
 
 # DataTables DataStreams implementation
-function Data.schema(df::DataTable, ::Type{Data.Column})
+function Data.schema(df::DataTable, ::Type{Data.Batch})
     return Data.Schema(map(string, names(df)),
-                       DataType[typeof(A) for A in df.columns], size(df, 1))
+                       Type[typeof(A) for A in df.columns], size(df, 1))
 end
 
 # DataTable as a Data.Source
@@ -210,118 +210,60 @@ function Data.isdone(source::DataTable, row, col)
     return row > rows || col > cols
 end
 
-Data.streamtype(::Type{DataTable}, ::Type{Data.Column}) = true
-Data.streamtype(::Type{DataTable}, ::Type{Data.Field}) = true
+Data.streamtype(::Type{DataTable}, ::Type{Data.Batch}) = true
+Data.streamtype(::Type{DataTable}, ::Type{Data.Row}) = true
 
-Data.streamfrom{T <: AbstractVector}(source::DataTable, ::Type{Data.Column}, ::Type{T}, col) =
-    (@inbounds A = source.columns[col]::T; return A)
-Data.streamfrom{T}(source::DataTable, ::Type{Data.Column}, ::Type{T}, col) =
-    (@inbounds A = source.columns[col]; return A)
-Data.streamfrom{T}(source::DataTable, ::Type{Data.Field}, ::Type{T}, row, col) =
-    (@inbounds A = Data.streamfrom(source, Data.Column, T, col); return A[row]::T)
+# Data.streamfrom{T <: AbstractVector}(source::DataTable, ::Type{Data.Batch}, ::Type{T}, col) =
+#     (A = source.columns[col]::T; return A)
+Data.streamfrom{T}(source::DataTable, ::Type{Data.Batch}, ::Type{T}, col) =
+    (A = source.columns[col]::AbstractVector{T}; return A)
+Data.streamfrom{T}(source::DataTable, ::Type{Data.Row}, ::Type{T}, row, col) =
+    (A = source.columns[col]::AbstractVector{T}; return A[row]::T)
 
 # DataTable as a Data.Sink
-allocate{T}(::Type{T}, rows, ref) = Array{T}(rows)
-allocate{T}(::Type{Vector{T}}, rows, ref) = Array{T}(rows)
-
-allocate{T}(::Type{Nullable{T}}, rows, ref) =
-    NullableArray{T, 1}(Array{T}(rows), fill(true, rows), isempty(ref) ? UInt8[] : ref)
-allocate{T}(::Type{NullableVector{T}}, rows, ref) =
-    NullableArray{T, 1}(Array{T}(rows), fill(true, rows), isempty(ref) ? UInt8[] : ref)
-
-allocate{S,R}(::Type{CategoricalArrays.CategoricalValue{S,R}}, rows, ref) =
-    CategoricalArray{S,1,R}(rows)
-allocate{S,R}(::Type{CategoricalVector{S,R}}, rows, ref) =
-    CategoricalArray{S,1,R}(rows)
-
-allocate{S,R}(::Type{Nullable{CategoricalArrays.CategoricalValue{S,R}}}, rows, ref) =
-    NullableCategoricalArray{S,1,R}(rows)
-allocate{S,R}(::Type{NullableCategoricalVector{S,R}}, rows, ref) =
-    NullableCategoricalArray{S,1,R}(rows)
+allocate{T}(::Type{T}, rows) = Vector{T}(rows)
+allocate{T}(::Type{Vector{T}}, rows) = Vector{T}(rows)
 
 function DataTable{T <: Data.StreamType}(sch::Data.Schema,
-                                         ::Type{T}=Data.Field,
-                                         append::Bool=false,
-                                         ref::Vector{UInt8}=UInt8[], args...)
+                                         ::Type{T}=Data.Row,
+                                         append::Bool=false)
     rows, cols = size(sch)
-    rows = max(0, T <: Data.Column ? 0 : rows) # don't pre-allocate for Column streaming
+    rows = max(0, T <: Data.Batch ? 0 : rows) # don't pre-allocate for Column streaming
     columns = Vector{Any}(cols)
     types = Data.types(sch)
     for i = 1:cols
-        columns[i] = allocate(types[i], rows, ref)
+        columns[i] = allocate(types[i], rows)
     end
     return DataTable(columns, map(Symbol, Data.header(sch)))
 end
 
 # given an existing DataTable (`sink`), make any necessary changes for streaming source
 # with Data.Schema `sch` to it, given we know if we'll be `appending` or not
-function DataTable(sink, sch::Data.Schema, ::Type{Data.Field}, append::Bool,
-                   ref::Vector{UInt8})
+function DataTable(sink, sch::Data.Schema, ::Type{Data.Row}, append::Bool)
     rows, cols = size(sch)
     newsize = max(0, rows) + (append ? size(sink, 1) : 0)
-    # need to make sure we don't break a NullableVector{WeakRefString{UInt8}} when appending
-    if append
-        for (i, T) in enumerate(Data.types(sch))
-            if T <: Nullable{WeakRefString{UInt8}}
-                sink.columns[i] = NullableArray(String[string(get(x, "")) for x in sink.columns[i]])
-                sch.types[i] = Nullable{String}
-            end
-        end
-    end
     newsize != size(sink, 1) && foreach(x->resize!(x, newsize), sink.columns)
     sch.rows = newsize
     return sink
 end
-function DataTable(sink, sch::Data.Schema, ::Type{Data.Column}, append::Bool, ref::Vector{UInt8})
+function DataTable(sink, sch::Data.Schema, ::Type{Data.Batch}, append::Bool)
     rows, cols = size(sch)
     append ? (sch.rows += size(sink, 1)) : foreach(empty!, sink.columns)
     return sink
 end
 
-Data.streamtypes(::Type{DataTable}) = [Data.Column, Data.Field]
+Data.streamtypes(::Type{DataTable}) = [Data.Batch, Data.Row]
 
-Data.streamto!{T}(sink::DataTable, ::Type{Data.Field}, val::T, row, col, sch::Data.Schema{false}) =
-    push!(sink.columns[col]::Vector{T}, val)
-Data.streamto!{T}(sink::DataTable, ::Type{Data.Field}, val::Nullable{T}, row, col, sch::Data.Schema{false}) =
-    push!(sink.columns[col]::NullableVector{T}, val)
-Data.streamto!{T, R}(sink::DataTable, ::Type{Data.Field}, val::CategoricalValue{T, R}, row, col, sch::Data.Schema{false}) =
-    push!(sink.columns[col]::CategoricalVector{T, R}, val)
-Data.streamto!{T, R}(sink::DataTable, ::Type{Data.Field}, val::Nullable{CategoricalValue{T, R}}, row, col, sch::Data.Schema{false}) =
-    push!(sink.columns[col]::NullableCategoricalVector{T, R}, val)
-Data.streamto!{T}(sink::DataTable, ::Type{Data.Field}, val::T, row, col, sch::Data.Schema{true}) =
-    (sink.columns[col]::Vector{T})[row] = val
-Data.streamto!{T}(sink::DataTable, ::Type{Data.Field}, val::Nullable{T}, row, col, sch::Data.Schema{true}) =
-    (sink.columns[col]::NullableVector{T})[row] = val
-Data.streamto!(sink::DataTable, ::Type{Data.Field}, val::Nullable{WeakRefString{UInt8}}, row, col, sch::Data.Schema{true}) =
-    sink.columns[col][row] = val
-Data.streamto!{T, R}(sink::DataTable, ::Type{Data.Field}, val::CategoricalValue{T, R}, row, col, sch::Data.Schema{true}) =
-    (sink.columns[col]::CategoricalVector{T, R})[row] = val
-Data.streamto!{T, R}(sink::DataTable, ::Type{Data.Field}, val::Nullable{CategoricalValue{T, R}}, row, col, sch::Data.Schema{true}) =
-    (sink.columns[col]::NullableCategoricalVector{T, R})[row] = val
+Data.streamto!{T}(sink::DataTable, ::Type{Data.Row}, val::T, row, col, sch::Data.Schema{false}) =
+    push!(sink.columns[col], val)
+Data.streamto!{T}(sink::DataTable, ::Type{Data.Row}, val::T, row, col, sch::Data.Schema{true}) =
+    (sink.columns[col])[row] = val
 
-function Data.streamto!{T}(sink::DataTable, ::Type{Data.Column}, column::T, row, col, sch::Data.Schema)
+function Data.streamto!{T}(sink::DataTable, ::Type{Data.Batch}, column::T, row, col, sch::Data.Schema)
     if row == 0
         sink.columns[col] = column
     else
         append!(sink.columns[col]::T, column)
     end
     return length(column)
-end
-
-function Base.append!{T}(dest::NullableVector{WeakRefString{T}}, column::NullableVector{WeakRefString{T}})
-    offset = length(dest.values)
-    parentoffset = length(dest.parent)
-    append!(dest.isnull, column.isnull)
-    append!(dest.parent, column.parent)
-    # appending new data to `dest` would invalid all existing WeakRefString pointers
-    resize!(dest.values, length(dest) + length(column))
-    for i = 1:offset
-        old = dest.values[i]
-        dest.values[i] = WeakRefString{T}(pointer(dest.parent, old.ind), old.len, old.ind)
-    end
-    for i = 1:length(column)
-        old = column.values[i]
-        dest.values[offset + i] = WeakRefString{T}(pointer(dest.parent, parentoffset + old.ind), old.len, parentoffset + old.ind)
-    end
-    return length(dest)
 end

--- a/src/abstractdatatable/io.jl
+++ b/src/abstractdatatable/io.jl
@@ -213,8 +213,6 @@ end
 Data.streamtype(::Type{DataTable}, ::Type{Data.Column}) = true
 Data.streamtype(::Type{DataTable}, ::Type{Data.Field}) = true
 
-# Data.streamfrom{T <: AbstractVector}(source::DataTable, ::Type{Data.Column}, ::Type{T}, col) =
-#     (A = source.columns[col]::T; return A)
 Data.streamfrom{T}(source::DataTable, ::Type{Data.Column}, ::Type{T}, col) =
     (A = source.columns[col]::AbstractVector{T}; return A)
 Data.streamfrom{T}(source::DataTable, ::Type{Data.Field}, ::Type{T}, row, col) =

--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -4,16 +4,13 @@
 
 # Like similar, but returns a array that can have nulls and is initialized with nulls
 similar_nullable{T}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    (v = Vector{?T}(dims); fill!(v, null); return v)
+    (v = Vector{Union{T, Null}}(dims); fill!(v, null); return v)
 
 similar_nullable{T >: Null}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    (v = Vector{?Nulls.T(T)}(dims); fill!(v, null); return v)
+    (v = Vector{T}(dims); fill!(v, null); return v)
 
 similar_nullable{T}(dv::CategoricalArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    NullableCategoricalArray{T}(dims)
-
-similar_nullable{T}(dv::NullableCategoricalArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    NullableCategoricalArray{T}(dims)
+    CategoricalArray{Union{T, Null}}(dims)
 
 # helper structure for DataTables joining
 immutable DataTableJoiner{DT1<:AbstractDataTable, DT2<:AbstractDataTable}

--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -2,11 +2,11 @@
 ## Join / merge
 ##
 
-# Like similar, but returns a array that can have nulls
+# Like similar, but returns a array that can have nulls and is initialized with nulls
 similar_nullable{T}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
     (v = Vector{?T}(dims); fill!(v, null); return v)
 
-similar_nullable{T <: Union}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
+similar_nullable{T >: Null}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
     (v = Vector{?Nulls.T(T)}(dims); fill!(v, null); return v)
 
 similar_nullable{T}(dv::CategoricalArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =

--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -4,13 +4,7 @@
 
 # Like similar, but returns a array that can have nulls and is initialized with nulls
 similar_nullable{T}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    (v = Vector{Union{T, Null}}(dims); fill!(v, null); return v)
-
-similar_nullable{T >: Null}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    (v = Vector{T}(dims); fill!(v, null); return v)
-
-similar_nullable{T}(dv::CategoricalArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    CategoricalArray{Union{T, Null}}(dims)
+    fill!(similar(dv, Union{T, Null}, dims), null)
 
 # helper structure for DataTables joining
 immutable DataTableJoiner{DT1<:AbstractDataTable, DT2<:AbstractDataTable}

--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -23,9 +23,9 @@ immutable DataTableJoiner{DT1<:AbstractDataTable, DT2<:AbstractDataTable}
     dtr_on::DT2
     on_cols::Vector{Symbol}
 
-    function DataTableJoiner{DT1, DT2}(dtl::DT1, dtr::DT2, on::Union{Symbol,Vector{Symbol}})
+    function DataTableJoiner{DT1, DT2}(dtl::DT1, dtr::DT2, on::Union{Symbol,Vector{Symbol}}) where {DT1, DT2}
         on_cols = isa(on, Symbol) ? [on] : on
-        new{DT1, DT2}(dtl, dtr, dtl[on_cols], dtr[on_cols], on_cols)
+        new(dtl, dtr, dtl[on_cols], dtr[on_cols], on_cols)
     end
 end
 

--- a/src/abstractdatatable/join.jl
+++ b/src/abstractdatatable/join.jl
@@ -2,12 +2,12 @@
 ## Join / merge
 ##
 
-# Like similar, but returns a nullable array
+# Like similar, but returns a array that can have nulls
 similar_nullable{T}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    NullableArray{T}(dims)
+    (v = Vector{?T}(dims); fill!(v, null); return v)
 
-similar_nullable{T<:Nullable}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
-    NullableArray{eltype(T)}(dims)
+similar_nullable{T <: Union}(dv::AbstractArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
+    (v = Vector{?Nulls.T(T)}(dims); fill!(v, null); return v)
 
 similar_nullable{T}(dv::CategoricalArray{T}, dims::Union{Int, Tuple{Vararg{Int}}}) =
     NullableCategoricalArray{T}(dims)
@@ -23,9 +23,9 @@ immutable DataTableJoiner{DT1<:AbstractDataTable, DT2<:AbstractDataTable}
     dtr_on::DT2
     on_cols::Vector{Symbol}
 
-    function DataTableJoiner(dtl::DT1, dtr::DT2, on::Union{Symbol,Vector{Symbol}})
+    function DataTableJoiner{DT1, DT2}(dtl::DT1, dtr::DT2, on::Union{Symbol,Vector{Symbol}})
         on_cols = isa(on, Symbol) ? [on] : on
-        new(dtl, dtr, dtl[on_cols], dtr[on_cols], on_cols)
+        new{DT1, DT2}(dtl, dtr, dtl[on_cols], dtr[on_cols], on_cols)
     end
 end
 

--- a/src/abstractdatatable/reshape.jl
+++ b/src/abstractdatatable/reshape.jl
@@ -316,7 +316,8 @@ Base.size(v::StackedVector) = (length(v),)
 Base.length(v::StackedVector) = sum(map(length, v.components))
 Base.ndims(v::StackedVector) = 1
 Base.eltype(v::StackedVector) = promote_type(map(eltype, v.components)...)
-Base.similar(v::StackedVector, T, dims::Dims) = similar(v.components[1], T, dims)
+Base.similar(v::StackedVector, T::Type, dims::Union{Integer, AbstractUnitRange}...) =
+    similar(v.components[1], T, dims...)
 
 CategoricalArrays.CategoricalArray(v::StackedVector) = CategoricalArray(v[:]) # could be more efficient
 

--- a/src/abstractdatatable/reshape.jl
+++ b/src/abstractdatatable/reshape.jl
@@ -193,9 +193,9 @@ function unstack(dt::AbstractDataTable, rowkey::Int, colkey::Int, value::Int)
     # `rowkey` integer indicating which column to place along rows
     # `colkey` integer indicating which column to place along column headers
     # `value` integer indicating which column has values
-    refkeycol = NullableCategoricalArray(dt[rowkey])
+    refkeycol = CategoricalArray{Union{eltype(dt[rowkey]), Null}}(dt[rowkey])
     valuecol = dt[value]
-    keycol = NullableCategoricalArray(dt[colkey])
+    keycol = CategoricalArray{Union{eltype(dt[colkey]), Null}}(dt[colkey])
     Nrow = length(refkeycol.pool)
     Ncol = length(keycol.pool)
     payload = DataTable(Any[similar_nullable(valuecol, Nrow) for i in 1:Ncol], map(Symbol, levels(keycol)))
@@ -230,7 +230,7 @@ function unstack(dt::AbstractDataTable, colkey::Int, value::Int)
     for i in 1:length(groupidxs)
         rowkey[groupidxs[i]] = i
     end
-    keycol = NullableCategoricalArray(dt[colkey])
+    keycol = CategoricalArray{Union{eltype(dt[colkey]), Null}}(dt[colkey])
     valuecol = dt[value]
     dt1 = nullable!(dt[g.idx[g.starts], g.cols], g.cols)
     Nrow = length(g)

--- a/src/abstractdatatable/reshape.jl
+++ b/src/abstractdatatable/reshape.jl
@@ -108,7 +108,7 @@ function stack(dt::AbstractDataTable, measure_vars, id_vars;
 end
 # no vars specified, by default select only numeric columns
 numeric_vars(dt::AbstractDataTable) =
-    [T <: AbstractFloat || (T <: Nullable && eltype(T) <: AbstractFloat)
+    [T <: AbstractFloat || (T >: Null && Nulls.T(T) <: AbstractFloat)
      for T in eltypes(dt)]
 
 function stack(dt::AbstractDataTable, measure_vars = numeric_vars(dt);

--- a/src/abstractdatatable/show.jl
+++ b/src/abstractdatatable/show.jl
@@ -64,14 +64,6 @@ end
 ourshowcompact(io::IO, x::Any) = showcompact(io, x) # -> Void
 ourshowcompact(io::IO, x::AbstractString) = print(io, x) # -> Void
 ourshowcompact(io::IO, x::Symbol) = print(io, x) # -> Void
-<<<<<<< HEAD
-ourshowcompact{T<:AbstractString}(io::IO, x::CategoricalValue{T}) =
-    print(io, String(x)) # -> Void
-ourshowcompact(io::IO, x::Nullable) =
-    isnull(x) ? showcompact(io, x) : ourshowcompact(io, unsafe_get(x)) # -> Void
-=======
-ourshowcompact(io::IO, x::(?String)) = isnull(x) ? showcompact(io, x) : print(io, x) # -> Void
->>>>>>> Additional work to port over to Nulls
 
 #' @description
 #'

--- a/src/abstractdatatable/show.jl
+++ b/src/abstractdatatable/show.jl
@@ -64,10 +64,14 @@ end
 ourshowcompact(io::IO, x::Any) = showcompact(io, x) # -> Void
 ourshowcompact(io::IO, x::AbstractString) = print(io, x) # -> Void
 ourshowcompact(io::IO, x::Symbol) = print(io, x) # -> Void
+<<<<<<< HEAD
 ourshowcompact{T<:AbstractString}(io::IO, x::CategoricalValue{T}) =
     print(io, String(x)) # -> Void
 ourshowcompact(io::IO, x::Nullable) =
     isnull(x) ? showcompact(io, x) : ourshowcompact(io, unsafe_get(x)) # -> Void
+=======
+ourshowcompact(io::IO, x::(?String)) = isnull(x) ? showcompact(io, x) : print(io, x) # -> Void
+>>>>>>> Additional work to port over to Nulls
 
 #' @description
 #'

--- a/src/abstractdatatable/show.jl
+++ b/src/abstractdatatable/show.jl
@@ -64,6 +64,8 @@ end
 ourshowcompact(io::IO, x::Any) = showcompact(io, x) # -> Void
 ourshowcompact(io::IO, x::AbstractString) = print(io, x) # -> Void
 ourshowcompact(io::IO, x::Symbol) = print(io, x) # -> Void
+ourshowcompact(io::IO, x::CategoricalValue{<:AbstractString}) =
+    print(io, String(x)) # -> Void
 
 #' @description
 #'

--- a/src/datatable/datatable.jl
+++ b/src/datatable/datatable.jl
@@ -130,8 +130,7 @@ function DataTable{T<:Type}(column_eltypes::AbstractVector{T}, cnames::AbstractV
             if elty <: CategoricalValue
                 columns[j] = NullableCategoricalArray{Nulls.T(elty)}(nrows)
             else
-                columns[j] = Vector{elty}(nrows)
-                fill!(columns[j], null)
+                columns[j] = nulls(elty, nrows)
             end
         else
             if elty <: CategoricalValue

--- a/src/datatable/datatable.jl
+++ b/src/datatable/datatable.jl
@@ -213,7 +213,7 @@ end
 
 # dt[MultiColumnIndex] => DataTable
 function Base.getindex{T <: ?ColumnIndex}(dt::DataTable,
-                                         col_inds::AbstractVector{T})
+                                          col_inds::AbstractVector{T})
     selected_columns = index(dt)[col_inds]
     new_columns = dt.columns[selected_columns]
     return DataTable(new_columns, Index(_names(dt)[selected_columns]))
@@ -230,8 +230,8 @@ end
 
 # dt[SingleRowIndex, MultiColumnIndex] => DataTable
 function Base.getindex{T <: ?ColumnIndex}(dt::DataTable,
-                                         row_ind::Real,
-                                         col_inds::AbstractVector{T})
+                                          row_ind::Real,
+                                          col_inds::AbstractVector{T})
     selected_columns = index(dt)[col_inds]
     new_columns = Any[dv[[row_ind]] for dv in dt.columns[selected_columns]]
     return DataTable(new_columns, Index(_names(dt)[selected_columns]))
@@ -239,16 +239,16 @@ end
 
 # dt[MultiRowIndex, SingleColumnIndex] => AbstractVector
 function Base.getindex{T <: ?Real}(dt::DataTable,
-                                  row_inds::AbstractVector{T},
-                                  col_ind::ColumnIndex)
+                                   row_inds::AbstractVector{T},
+                                   col_ind::ColumnIndex)
     selected_column = index(dt)[col_ind]
     return dt.columns[selected_column][row_inds]
 end
 
 # dt[MultiRowIndex, MultiColumnIndex] => DataTable
 function Base.getindex{R <: ?Real, T <: ?ColumnIndex}(dt::DataTable,
-                                                    row_inds::AbstractVector{R},
-                                                    col_inds::AbstractVector{T})
+                                                      row_inds::AbstractVector{R},
+                                                      col_inds::AbstractVector{T})
     selected_columns = index(dt)[col_inds]
     new_columns = Any[dv[row_inds] for dv in dt.columns[selected_columns]]
     return DataTable(new_columns, Index(_names(dt)[selected_columns]))
@@ -266,8 +266,8 @@ Base.getindex(dt::DataTable, row_ind::Real, col_inds::Colon) = dt[[row_ind], col
 
 # dt[MultiRowIndex, :] => DataTable
 function Base.getindex{R <: ?Real}(dt::DataTable,
-                                row_inds::AbstractVector{R},
-                                col_inds::Colon)
+                                   row_inds::AbstractVector{R},
+                                   col_inds::Colon)
     new_columns = Any[dv[row_inds] for dv in dt.columns]
     return DataTable(new_columns, copy(index(dt)))
 end

--- a/src/datatable/datatable.jl
+++ b/src/datatable/datatable.jl
@@ -151,7 +151,11 @@ function DataTable{T<:Type}(column_eltypes::AbstractVector{T}, cnames::AbstractV
     updated_types = convert(Vector{Type}, column_eltypes)
     for i in eachindex(nominal)
         nominal[i] || continue
-        updated_types[i] = Union{CategoricalValue{Nulls.T{updated_types[i]}}, Null}
+        if updated_types[i] >: Null
+            updated_types[i] = Union{CategoricalValue{Nulls.T{updated_types[i]}}, Null}
+        else
+            updated_types[i] = CategoricalValue{updated_types[i]}
+        end
     end
     return DataTable(updated_types, cnames, nrows)
 end

--- a/src/datatable/datatable.jl
+++ b/src/datatable/datatable.jl
@@ -87,6 +87,7 @@ type DataTable <: AbstractDataTable
             # recycle scalars
             for i in 1:length(columns)
                 isa(columns[i], AbstractArray) && continue
+                #TODO: should we make this a Vector{?T} by default? depending on other columns?
                 columns[i] = fill(columns[i], maxlen)
                 lengths[i] = maxlen
             end
@@ -126,11 +127,12 @@ function DataTable{T<:Type}(column_eltypes::AbstractVector{T}, cnames::AbstractV
     columns = Vector{Any}(numcols)
     for j in 1:numcols
         elty = column_eltypes[j]
-        if elty <: Nullable
-            if eltype(elty) <: CategoricalValue
-                columns[j] = NullableCategoricalArray{eltype(elty)}(nrows)
+        if elty >: Null
+            if elty <: CategoricalValue
+                columns[j] = NullableCategoricalArray{Nulls.T(elty)}(nrows)
             else
-                columns[j] = NullableVector{eltype(elty)}(nrows)
+                columns[j] = Vector{elty}(nrows)
+                fill!(columns[j], null)
             end
         else
             if elty <: CategoricalValue
@@ -151,11 +153,7 @@ function DataTable{T<:Type}(column_eltypes::AbstractVector{T}, cnames::AbstractV
     updated_types = convert(Vector{Type}, column_eltypes)
     for i in eachindex(nominal)
         nominal[i] || continue
-        if updated_types[i] <: Nullable
-            updated_types[i] = Nullable{CategoricalValue{eltype(updated_types[i])}}
-        else
-            updated_types[i] = CategoricalValue{updated_types[i]}
-        end
+        updated_types[i] = CategoricalValue{updated_types[i]}
     end
     return DataTable(updated_types, cnames, nrows)
 end
@@ -214,9 +212,8 @@ function Base.getindex(dt::DataTable, col_ind::ColumnIndex)
 end
 
 # dt[MultiColumnIndex] => DataTable
-function Base.getindex{T <: ColumnIndex}(dt::DataTable,
-                                         col_inds::Union{AbstractVector{T},
-                                                         AbstractVector{Nullable{T}}})
+function Base.getindex{T <: ?ColumnIndex}(dt::DataTable,
+                                         col_inds::AbstractVector{T})
     selected_columns = index(dt)[col_inds]
     new_columns = dt.columns[selected_columns]
     return DataTable(new_columns, Index(_names(dt)[selected_columns]))
@@ -232,29 +229,26 @@ function Base.getindex(dt::DataTable, row_ind::Real, col_ind::ColumnIndex)
 end
 
 # dt[SingleRowIndex, MultiColumnIndex] => DataTable
-function Base.getindex{T <: ColumnIndex}(dt::DataTable,
+function Base.getindex{T <: ?ColumnIndex}(dt::DataTable,
                                          row_ind::Real,
-                                         col_inds::Union{AbstractVector{T},
-                                                         AbstractVector{Nullable{T}}})
+                                         col_inds::AbstractVector{T})
     selected_columns = index(dt)[col_inds]
     new_columns = Any[dv[[row_ind]] for dv in dt.columns[selected_columns]]
     return DataTable(new_columns, Index(_names(dt)[selected_columns]))
 end
 
 # dt[MultiRowIndex, SingleColumnIndex] => AbstractVector
-function Base.getindex{T <: Real}(dt::DataTable,
-                                  row_inds::Union{AbstractVector{T}, AbstractVector{Nullable{T}}},
+function Base.getindex{T <: ?Real}(dt::DataTable,
+                                  row_inds::AbstractVector{T},
                                   col_ind::ColumnIndex)
     selected_column = index(dt)[col_ind]
     return dt.columns[selected_column][row_inds]
 end
 
 # dt[MultiRowIndex, MultiColumnIndex] => DataTable
-function Base.getindex{R <: Real, T <: ColumnIndex}(dt::DataTable,
-                                                    row_inds::Union{AbstractVector{R},
-                                                                    AbstractVector{Nullable{R}}},
-                                                    col_inds::Union{AbstractVector{T},
-                                                                    AbstractVector{Nullable{T}}})
+function Base.getindex{R <: ?Real, T <: ?ColumnIndex}(dt::DataTable,
+                                                    row_inds::AbstractVector{R},
+                                                    col_inds::AbstractVector{T})
     selected_columns = index(dt)[col_inds]
     new_columns = Any[dv[row_inds] for dv in dt.columns[selected_columns]]
     return DataTable(new_columns, Index(_names(dt)[selected_columns]))
@@ -262,19 +256,17 @@ end
 
 # dt[:, SingleColumnIndex] => AbstractVector
 # dt[:, MultiColumnIndex] => DataTable
-Base.getindex{T<:ColumnIndex}(dt::DataTable,
-                              row_inds::Colon,
-                              col_inds::Union{T, AbstractVector{T},
-                                              AbstractVector{Nullable{T}}}) =
+Base.getindex{T <: ?ColumnIndex}(dt::DataTable,
+                                 ::Colon,
+                                 col_inds::Union{T, AbstractVector{T}}) =
     dt[col_inds]
 
 # dt[SingleRowIndex, :] => DataTable
 Base.getindex(dt::DataTable, row_ind::Real, col_inds::Colon) = dt[[row_ind], col_inds]
 
 # dt[MultiRowIndex, :] => DataTable
-function Base.getindex{R<:Real}(dt::DataTable,
-                                row_inds::Union{AbstractVector{R},
-                                                AbstractVector{Nullable{R}}},
+function Base.getindex{R <: ?Real}(dt::DataTable,
+                                row_inds::AbstractVector{R},
                                 col_inds::Colon)
     new_columns = Any[dv[row_inds] for dv in dt.columns]
     return DataTable(new_columns, copy(index(dt)))
@@ -602,7 +594,7 @@ Base.setindex!(dt::DataTable, v, ::Colon, col_inds) =
     (dt[col_inds] = v; dt)
 
 # Special deletion assignment
-Base.setindex!(dt::DataTable, x::Void, col_ind::Int) = delete!(dt, col_ind)
+Base.setindex!(dt::DataTable, x::Null, col_ind::Int) = delete!(dt, col_ind)
 
 ##############################################################################
 ##
@@ -613,16 +605,6 @@ Base.setindex!(dt::DataTable, x::Void, col_ind::Int) = delete!(dt, col_ind)
 Base.empty!(dt::DataTable) = (empty!(dt.columns); empty!(index(dt)); dt)
 
 function Base.insert!(dt::DataTable, col_ind::Int, item::AbstractVector, name::Symbol)
-    0 < col_ind <= ncol(dt) + 1 || throw(BoundsError())
-    size(dt, 1) == length(item) || size(dt, 1) == 0 || error("number of rows does not match")
-
-    insert!(index(dt), col_ind, name)
-    insert!(dt.columns, col_ind, item)
-    dt
-end
-
-# FIXME: Needed to work around a crash: JuliaLang/julia#18299
-function Base.insert!(dt::DataTable, col_ind::Int, item::NullableArray, name::Symbol)
     0 < col_ind <= ncol(dt) + 1 || throw(BoundsError())
     size(dt, 1) == length(item) || size(dt, 1) == 0 || error("number of rows does not match")
 
@@ -749,7 +731,7 @@ Base.hcat(dt1::DataTable, dt2::AbstractDataTable, dtn::AbstractDataTable...) = h
 ##############################################################################
 
 function nullable!(dt::DataTable, col::ColumnIndex)
-    dt[col] = NullableArray(dt[col])
+    dt[col] = Vector{?eltype(dt[col])}(dt[col])
     dt
 end
 function nullable!{T <: ColumnIndex}(dt::DataTable, cols::Vector{T})

--- a/src/datatable/datatable.jl
+++ b/src/datatable/datatable.jl
@@ -593,7 +593,7 @@ Base.setindex!(dt::DataTable, v, ::Colon, col_inds) =
     (dt[col_inds] = v; dt)
 
 # Special deletion assignment
-Base.setindex!(dt::DataTable, x::Null, col_ind::Int) = delete!(dt, col_ind)
+Base.setindex!(dt::DataTable, x::Void, col_ind::Int) = delete!(dt, col_ind)
 
 ##############################################################################
 ##

--- a/src/datatablerow/datatablerow.jl
+++ b/src/datatablerow/datatablerow.jl
@@ -73,6 +73,19 @@ end
 isequal_colel(col::AbstractArray, r1::Int, r2::Int) =
     (r1 == r2) || isequal(Base.unsafe_getindex(col, r1), Base.unsafe_getindex(col, r2))
 
+# table columns are passed as a tuple of vectors to ensure type specialization
+isequal_row(cols::Tuple{AbstractVector}, r1::Int, r2::Int) =
+    isequal(cols[1][r1], cols[1][r2])
+isequal_row(cols::Tuple{Vararg{AbstractVector}}, r1::Int, r2::Int) =
+    isequal(cols[1][r1], cols[1][r2]) && isequal_row(Base.tail(cols), r1, r2)
+
+isequal_row(cols1::Tuple{AbstractVector}, r1::Int, cols2::Tuple{AbstractVector}, r2::Int) =
+    isequal(cols1[1][r1], cols2[1][r2])
+isequal_row(cols1::Tuple{Vararg{AbstractVector}}, r1::Int,
+            cols2::Tuple{Vararg{AbstractVector}}, r2::Int) =
+    isequal(cols1[1][r1], cols2[1][r2]) &&
+        isequal_row(Base.tail(cols1), r1, Base.tail(cols2), r2)
+
 function isequal_row(dt1::AbstractDataTable, r1::Int, dt2::AbstractDataTable, r2::Int)
     if dt1 === dt2
         if r1 == r2

--- a/src/datatablerow/datatablerow.jl
+++ b/src/datatablerow/datatablerow.jl
@@ -39,9 +39,9 @@ Base.convert(::Type{Array}, r::DataTableRow) = convert(Array, r.dt[r.row,:])
 
 # hash column element
 Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) = hash(v[i], h)
-Base.@propagate_inbounds hash_colel{T}(v::AbstractCategoricalArray{T}, i, h::UInt = zero(UInt)) =
+Base.@propagate_inbounds hash_colel(v::AbstractCategoricalArray, i, h::UInt = zero(UInt)) =
     hash(CategoricalArrays.index(v.pool)[v.refs[i]], h)
-Base.@propagate_inbounds function hash_colel{T}(v::AbstractNullableCategoricalArray{T}, i, h::UInt = zero(UInt))
+Base.@propagate_inbounds function hash_colel(v::AbstractCategoricalArray{>: Null}, i, h::UInt = zero(UInt))
     ref = v.refs[i]
     ref == 0 ? hash(null, h) : hash(CategoricalArrays.index(v.pool)[ref], h)
 end
@@ -62,7 +62,6 @@ Base.hash(r::DataTableRow, h::UInt = zero(UInt)) =
 # comparison of DataTable rows
 # only the rows of the same DataTable could be compared
 # rows are equal if they have the same values (while the row indices could differ)
-# returns Nullable{Bool}
 # if all non-null values are equal, but there are nulls, returns null
 Base.:(==)(r1::DataTableRow, r2::DataTableRow) = isequal(r1, r2)
 

--- a/src/datatablerow/datatablerow.jl
+++ b/src/datatablerow/datatablerow.jl
@@ -43,7 +43,7 @@ Base.@propagate_inbounds hash_colel{T}(v::AbstractCategoricalArray{T}, i, h::UIn
     hash(CategoricalArrays.index(v.pool)[v.refs[i]], h)
 Base.@propagate_inbounds function hash_colel{T}(v::AbstractNullableCategoricalArray{T}, i, h::UInt = zero(UInt))
     ref = v.refs[i]
-    ref == 0 ? h + Base.nullablehash_seed : hash(CategoricalArrays.index(v.pool)[ref], h)
+    ref == 0 ? hash(null, h) : hash(CategoricalArrays.index(v.pool)[ref], h)
 end
 
 # hash of DataTable rows based on its values
@@ -64,7 +64,7 @@ Base.hash(r::DataTableRow, h::UInt = zero(UInt)) =
 # rows are equal if they have the same values (while the row indices could differ)
 # returns Nullable{Bool}
 # if all non-null values are equal, but there are nulls, returns null
-@compat(Base.:(==))(r1::DataTableRow, r2::DataTableRow) = isequal(r1, r2)
+Base.:(==)(r1::DataTableRow, r2::DataTableRow) = isequal(r1, r2)
 
 function Base.isequal(r1::DataTableRow, r2::DataTableRow)
     isequal_row(r1.dt, r1.row, r2.dt, r2.row)
@@ -73,21 +73,6 @@ end
 # internal method for comparing the elements of the same data table column
 isequal_colel(col::AbstractArray, r1::Int, r2::Int) =
     (r1 == r2) || isequal(Base.unsafe_getindex(col, r1), Base.unsafe_getindex(col, r2))
-
-isequal_colel(a::Any, b::Any) = isequal(a, b)
-
-# table columns are passed as a tuple of vectors to ensure type specialization
-isequal_row(cols::Tuple{AbstractVector}, r1::Int, r2::Int) =
-    isequal_colel(cols[1][r1], cols[1][r2])
-isequal_row(cols::Tuple{Vararg{AbstractVector}}, r1::Int, r2::Int) =
-    isequal_colel(cols[1][r1], cols[1][r2]) && isequal_row(Base.tail(cols), r1, r2)
-
-isequal_row(cols1::Tuple{AbstractVector}, r1::Int, cols2::Tuple{AbstractVector}, r2::Int) =
-    isequal_colel(cols1[1][r1], cols2[1][r2])
-isequal_row(cols1::Tuple{Vararg{AbstractVector}}, r1::Int,
-            cols2::Tuple{Vararg{AbstractVector}}, r2::Int) =
-    isequal_colel(cols1[1][r1], cols2[1][r2]) &&
-        isequal_row(Base.tail(cols1), r1, Base.tail(cols2), r2)
 
 function isequal_row(dt1::AbstractDataTable, r1::Int, dt2::AbstractDataTable, r2::Int)
     if dt1 === dt2
@@ -98,7 +83,7 @@ function isequal_row(dt1::AbstractDataTable, r1::Int, dt2::AbstractDataTable, r2
         throw(ArgumentError("Rows of the tables that have different number of columns cannot be compared. Got $(ncol(dt1)) and $(ncol(dt2)) columns"))
     end
     @inbounds for (col1, col2) in zip(columns(dt1), columns(dt2))
-        isequal_colel(col1[r1], col2[r2]) || return false
+        isequal(col1[r1], col2[r2]) || return false
     end
     return true
 end

--- a/src/datatablerow/utils.jl
+++ b/src/datatablerow/utils.jl
@@ -29,15 +29,6 @@ function hashrows_col!(h::Vector{UInt}, v::AbstractVector)
     h
 end
 
-function hashrows_col!{T >: Null}(h::Vector{UInt}, v::AbstractVector{T})
-    @inbounds for i in eachindex(h)
-        h[i] = isnull(v[i]) ?
-               hash(null, h[i]) :
-               hash(v[i], h[i])
-    end
-    h
-end
-
 # should give the same hash as AbstractVector{T}
 function hashrows_col!{T}(h::Vector{UInt}, v::AbstractCategoricalVector{T})
     # TODO is it possible to optimize by hashing the pool values once?

--- a/src/datatablerow/utils.jl
+++ b/src/datatablerow/utils.jl
@@ -29,16 +29,11 @@ function hashrows_col!(h::Vector{UInt}, v::AbstractVector)
     h
 end
 
-if !isdefined(Base, :unsafe_get)
-    unsafe_get(x::Nullable) = x.value
-    unsafe_get(x::Any) = x
-end
-
-function hashrows_col!{T<:Nullable}(h::Vector{UInt}, v::AbstractVector{T})
+function hashrows_col!{T >: Null}(h::Vector{UInt}, v::AbstractVector{T})
     @inbounds for i in eachindex(h)
         h[i] = isnull(v[i]) ?
-               h[i] + Base.nullablehash_seed :
-               hash(unsafe_get(v[i]), h[i])
+               hash(null, h[i]) :
+               hash(v[i], h[i])
     end
     h
 end
@@ -58,7 +53,7 @@ function hashrows_col!{T}(h::Vector{UInt}, v::AbstractNullableCategoricalVector{
     # TODO is it possible to optimize by hashing the pool values once?
     @inbounds for (i, ref) in enumerate(v.refs)
         h[i] = ref == 0 ?
-               h[i] + Base.nullablehash_seed :
+               hash(null, h[i]) :
                hash(CategoricalArrays.index(v.pool)[ref], h[i])
     end
     h

--- a/src/datatablerow/utils.jl
+++ b/src/datatablerow/utils.jl
@@ -38,9 +38,9 @@ function hashrows_col!{T}(h::Vector{UInt}, v::AbstractCategoricalVector{T})
     h
 end
 
-# should give the same hash as AbstractNullableVector{T}
+# should give the same hash as AbstractVector{T}
 # enables efficient sequential memory access pattern
-function hashrows_col!{T}(h::Vector{UInt}, v::AbstractNullableCategoricalVector{T})
+function hashrows_col!(h::Vector{UInt}, v::AbstractCategoricalVector{>: Null})
     # TODO is it possible to optimize by hashing the pool values once?
     @inbounds for (i, ref) in enumerate(v.refs)
         h[i] = ref == 0 ?

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -5,7 +5,7 @@ import Base: @deprecate
 @deprecate nullable!(colnames::Array{Symbol,1}, dt::AbstractDataTable) nullable!(dt, colnames)
 @deprecate nullable!(colnums::Array{Int,1}, dt::AbstractDataTable) nullable!(dt, colnums)
 
-import Base: keys, values, insert!, setindex!
+import Base: keys, values, insert!
 @deprecate keys(dt::AbstractDataTable) names(dt)
 @deprecate values(dt::AbstractDataTable) DataTables.columns(dt)
 @deprecate insert!(dt::DataTable, dt2::AbstractDataTable) merge!(dt, dt2)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -20,5 +20,3 @@ import Base: keys, values, insert!, setindex!
 
 @deprecate stackdf stackdt
 @deprecate meltdf meltdt
-
-@deprecate setindex!(dt::DataTable, x::Void, col_ind::Int) setindex!(dt, null, col_ind)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -5,7 +5,7 @@ import Base: @deprecate
 @deprecate nullable!(colnames::Array{Symbol,1}, dt::AbstractDataTable) nullable!(dt, colnames)
 @deprecate nullable!(colnums::Array{Int,1}, dt::AbstractDataTable) nullable!(dt, colnums)
 
-import Base: keys, values, insert!
+import Base: keys, values, insert!, setindex!
 @deprecate keys(dt::AbstractDataTable) names(dt)
 @deprecate values(dt::AbstractDataTable) DataTables.columns(dt)
 @deprecate insert!(dt::DataTable, dt2::AbstractDataTable) merge!(dt, dt2)
@@ -20,3 +20,5 @@ import Base: keys, values, insert!
 
 @deprecate stackdf stackdt
 @deprecate meltdf meltdt
+
+@deprecate setindex!(dt::DataTable, x::Void, col_ind::Int) setindex!(dt, null, col_ind)

--- a/src/groupeddatatable/grouping.jl
+++ b/src/groupeddatatable/grouping.jl
@@ -72,8 +72,8 @@ vcat([g[:b] for g in gd]...)
 for g in gd
     println(g)
 end
-map(d -> mean(dropnull(d[:c])), gd)   # returns a GroupApplied object
-combine(map(d -> mean(dropnull(d[:c])), gd))
+map(d -> mean(Nulls.skip(d[:c])), gd)   # returns a GroupApplied object
+combine(map(d -> mean(Nulls.skip(d[:c])), gd))
 dt |> groupby(:a) |> [sum, length]
 dt |> groupby([:a, :b]) |> [sum, length]
 ```
@@ -187,7 +187,7 @@ combine(ga::GroupApplied)
 dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
                b = repeat([2, 1], outer=[4]),
                c = randn(8))
-combine(map(d -> mean(dropnull(d[:c])), gd))
+combine(map(d -> mean(Nulls.skip(d[:c])), gd))
 ```
 
 """
@@ -284,11 +284,11 @@ dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
                b = repeat([2, 1], outer=[4]),
                c = randn(8))
 by(dt, :a, d -> sum(d[:c]))
-by(dt, :a, d -> 2 * dropnull(d[:c]))
-by(dt, :a, d -> DataTable(c_sum = sum(d[:c]), c_mean = mean(dropnull(d[:c]))))
-by(dt, :a, d -> DataTable(c = d[:c], c_mean = mean(dropnull(d[:c]))))
+by(dt, :a, d -> 2 * Nulls.skip(d[:c]))
+by(dt, :a, d -> DataTable(c_sum = sum(d[:c]), c_mean = mean(Nulls.skip(d[:c]))))
+by(dt, :a, d -> DataTable(c = d[:c], c_mean = mean(Nulls.skip(d[:c]))))
 by(dt, [:a, :b]) do d
-    DataTable(m = mean(dropnull(d[:c])), v = var(dropnull(d[:c])))
+    DataTable(m = mean(Nulls.skip(d[:c])), v = var(Nulls.skip(d[:c])))
 end
 ```
 
@@ -334,9 +334,9 @@ dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
                b = repeat([2, 1], outer=[4]),
                c = randn(8))
 aggregate(dt, :a, sum)
-aggregate(dt, :a, [sum, x->mean(dropnull(x))])
-aggregate(groupby(dt, :a), [sum, x->mean(dropnull(x))])
-dt |> groupby(:a) |> [sum, x->mean(dropnull(x))]   # equivalent
+aggregate(dt, :a, [sum, x->mean(Nulls.skip(x))])
+aggregate(groupby(dt, :a), [sum, x->mean(Nulls.skip(x))])
+dt |> groupby(:a) |> [sum, x->mean(Nulls.skip(x))]   # equivalent
 ```
 
 """

--- a/src/groupeddatatable/grouping.jl
+++ b/src/groupeddatatable/grouping.jl
@@ -240,20 +240,12 @@ colwise(sum, groupby(dt, :a))
 """
 function colwise(f, d::AbstractDataTable)
     x = [f(d[i]) for i in 1:ncol(d)]
-    if eltype(x) <: Nullable
-        return NullableArray(x)
-    else
-        return x
-    end
+    return x
 end
 # apply several functions to each column in a DataTable
 function colwise(fns::Union{AbstractVector, Tuple}, d::AbstractDataTable)
     x = [f(d[i]) for f in fns, i in 1:ncol(d)]
-    if eltype(x) <: Nullable
-        return NullableArray(x)
-    else
-        return x
-    end
+    return x
 end
 colwise(f, gd::GroupedDataTable) = [colwise(f, g) for g in gd]
 colwise(f) = x -> colwise(f, x)

--- a/src/groupeddatatable/grouping.jl
+++ b/src/groupeddatatable/grouping.jl
@@ -238,15 +238,10 @@ colwise(sum, groupby(dt, :a))
 ```
 
 """
-function colwise(f, d::AbstractDataTable)
-    x = [f(d[i]) for i in 1:ncol(d)]
-    return x
-end
+colwise(f, d::AbstractDataTable) = [f(d[i]) for i in 1:ncol(d)]
+
 # apply several functions to each column in a DataTable
-function colwise(fns::Union{AbstractVector, Tuple}, d::AbstractDataTable)
-    x = [f(d[i]) for f in fns, i in 1:ncol(d)]
-    return x
-end
+colwise(fns::Union{AbstractVector, Tuple}, d::AbstractDataTable) = [f(d[i]) for f in fns, i in 1:ncol(d)]
 colwise(f, gd::GroupedDataTable) = [colwise(f, g) for g in gd]
 colwise(f) = x -> colwise(f, x)
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -112,7 +112,7 @@ end
 
 Base.getindex(x::Index, idx::Symbol) = x.lookup[idx]
 Base.getindex(x::AbstractIndex, idx::Real) = Int(idx)
-Base.getindex(x::AbstractIndex, idx::AbstractVector{?Bool}) =
+Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Null}}) =
     getindex(x, collect(Nulls.replace(idx, false)))
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool}) = find(idx)
 Base.getindex{T >: Null}(x::AbstractIndex, idx::AbstractVector{T}) =

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -113,10 +113,10 @@ end
 Base.getindex(x::Index, idx::Symbol) = x.lookup[idx]
 Base.getindex(x::AbstractIndex, idx::Real) = Int(idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{?Bool}) =
-    getindex(x, Bool[ifelse(isnull(x), false, x) for x in idx])
+    getindex(x, collect(Nulls.replace(idx, false)))
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool}) = find(idx)
 Base.getindex{T >: Null}(x::AbstractIndex, idx::AbstractVector{T}) =
-    getindex(x, [x for x in idx if !isnull(x)])
+    getindex(x, collect(Nulls.skip(idx)))
 Base.getindex(x::AbstractIndex, idx::Range) = [idx;]
 Base.getindex{T <: Real}(x::AbstractIndex, idx::AbstractVector{T}) = convert(Vector{Int}, idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Symbol}) = [x.lookup[i] for i in idx]

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -111,12 +111,12 @@ function Base.insert!(x::Index, idx::Integer, nm::Symbol)
 end
 
 Base.getindex(x::Index, idx::Symbol) = x.lookup[idx]
-Base.getindex(x::AbstractIndex, idx::Real) = @compat Int(idx)
-Base.getindex(x::AbstractIndex, idx::AbstractVector{Nullable{Bool}}) =
-    getindex(x, convert(Vector{Bool}, idx, false))
-Base.getindex{T<:Nullable}(x::AbstractIndex, idx::AbstractVector{T}) =
-    getindex(x, dropnull(idx))
+Base.getindex(x::AbstractIndex, idx::Real) = Int(idx)
+Base.getindex(x::AbstractIndex, idx::AbstractVector{?Bool}) =
+    getindex(x, Bool[ifelse(isnull(x), false, x) for x in idx])
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool}) = find(idx)
+Base.getindex{T >: Null}(x::AbstractIndex, idx::AbstractVector{T}) =
+    getindex(x, [x for x in idx if !isnull(x)])
 Base.getindex(x::AbstractIndex, idx::Range) = [idx;]
 Base.getindex{T <: Real}(x::AbstractIndex, idx::AbstractVector{T}) = convert(Vector{Int}, idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Symbol}) = [x.lookup[i] for i in idx]

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -117,23 +117,10 @@ end
 function countnull(a::AbstractArray)
     res = 0
     for x in a
-        res += _isnull(x)
+        res += isnull(x)
     end
     return res
 end
-
-#' @description
-#'
-#' Count the number of missing values in a NullableArray.
-#'
-#' @field a::NullableArray The NullableArray whose missing values are to be counted.
-#'
-#' @returns count::Int The number of null values in `a`.
-#'
-#' @examples
-#'
-#' DataTables.countnull(NullableArray([1, 2, 3]))
-countnull(a::NullableArray) = sum(a.isnull)
 
 #' @description
 #'
@@ -168,6 +155,3 @@ function _fnames{T<:Function}(fs::Vector{T})
     end
     names
 end
-
-_isnull(x::Any) = false
-_isnull(x::Nullable) = isnull(x)

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -124,7 +124,7 @@ end
 
 #' @description
 #'
-#' Count the number of missing values in a NullableCategoricalArray.
+#' Count the number of missing values in a CategoricalArray.
 #'
 #' @field na::CategoricalArray The CategoricalArray whose missing values
 #'        are to be counted.

--- a/src/subdatatable/subdatatable.jl
+++ b/src/subdatatable/subdatatable.jl
@@ -93,7 +93,7 @@ function SubDataTable(parent::DataTable, row::Integer)
     return SubDataTable(parent, [Int(row)])
 end
 
-function SubDataTable{S <: Integer}(parent::DataTable, rows::AbstractVector{S})
+function SubDataTable(parent::DataTable, rows::AbstractVector{<:?Integer})
     return SubDataTable(parent, convert(Vector{Int}, rows))
 end
 
@@ -101,7 +101,7 @@ function SubDataTable(parent::DataTable, rows::AbstractVector{Bool})
     return SubDataTable(parent, find(rows))
 end
 
-function SubDataTable{T<:Integer}(sdt::SubDataTable, rowinds::Union{T, AbstractVector{T}})
+function SubDataTable{T<:?Integer}(sdt::SubDataTable, rowinds::Union{T, AbstractVector{T}})
     return SubDataTable(sdt.parent, sdt.rows[rowinds])
 end
 

--- a/src/subdatatable/subdatatable.jl
+++ b/src/subdatatable/subdatatable.jl
@@ -93,7 +93,7 @@ function SubDataTable(parent::DataTable, row::Integer)
     return SubDataTable(parent, [Int(row)])
 end
 
-function SubDataTable(parent::DataTable, rows::AbstractVector{<:?Integer})
+function SubDataTable(parent::DataTable, rows::AbstractVector{<:Union{Integer, Null}})
     return SubDataTable(parent, convert(Vector{Int}, rows))
 end
 
@@ -101,7 +101,7 @@ function SubDataTable(parent::DataTable, rows::AbstractVector{Bool})
     return SubDataTable(parent, find(rows))
 end
 
-function SubDataTable{T<:?Integer}(sdt::SubDataTable, rowinds::Union{T, AbstractVector{T}})
+function SubDataTable{T<:Union{Integer, Null}}(sdt::SubDataTable, rowinds::Union{T, AbstractVector{T}})
     return SubDataTable(sdt.parent, sdt.rows[rowinds])
 end
 

--- a/src/subdatatable/subdatatable.jl
+++ b/src/subdatatable/subdatatable.jl
@@ -105,15 +105,10 @@ function SubDataTable{T<:Integer}(sdt::SubDataTable, rowinds::Union{T, AbstractV
     return SubDataTable(sdt.parent, sdt.rows[rowinds])
 end
 
-function Base.view{T<:Nullable}(adt::AbstractDataTable, rowinds::AbstractVector{T})
-    # Vector{<:Nullable} need to be checked for nulls and the values lifted
+function Base.view(adt::AbstractDataTable, rowinds::AbstractVector{>:Null})
+    # Vector{>:Null} need to be checked for nulls and the values lifted
     any(isnull, rowinds) && throw(NullException())
-    return SubDataTable(adt, get.(rowinds))
-end
-
-function Base.view(adt::AbstractDataTable, rowinds::NullableVector)
-    # convert for NullableVectors will throw NullException if nulls present
-    return SubDataTable(adt, convert(Vector, rowinds))
+    return SubDataTable(adt, rowinds)
 end
 
 function Base.view(adt::AbstractDataTable, rowinds::Any)

--- a/src/subdatatable/subdatatable.jl
+++ b/src/subdatatable/subdatatable.jl
@@ -85,7 +85,7 @@ sdt1[:,[:a,:b]]
 """
 SubDataTable
 
-function SubDataTable{T <: AbstractVector{Int}}(parent::DataTable, rows::T)
+function SubDataTable(parent::DataTable, rows::T) where {T <: AbstractVector{Int}}
     return SubDataTable{T}(parent, rows)
 end
 
@@ -93,7 +93,7 @@ function SubDataTable(parent::DataTable, row::Integer)
     return SubDataTable(parent, [Int(row)])
 end
 
-function SubDataTable(parent::DataTable, rows::AbstractVector{<:Union{Integer, Null}})
+function SubDataTable(parent::DataTable, rows::AbstractVector{<:Integer})
     return SubDataTable(parent, convert(Vector{Int}, rows))
 end
 
@@ -101,14 +101,14 @@ function SubDataTable(parent::DataTable, rows::AbstractVector{Bool})
     return SubDataTable(parent, find(rows))
 end
 
-function SubDataTable{T<:Union{Integer, Null}}(sdt::SubDataTable, rowinds::Union{T, AbstractVector{T}})
+function SubDataTable(sdt::SubDataTable, rowinds::Union{T, AbstractVector{T}}) where {T <: Integer}
     return SubDataTable(sdt.parent, sdt.rows[rowinds])
 end
 
-function Base.view(adt::AbstractDataTable, rowinds::AbstractVector{>:Null})
-    # Vector{>:Null} need to be checked for nulls and the values lifted
+function Base.view(adt::AbstractDataTable, rowinds::AbstractVector{T}) where {T >: Null}
+    # Vector{>:Null} need to be checked for nulls
     any(isnull, rowinds) && throw(NullException())
-    return SubDataTable(adt, rowinds)
+    return SubDataTable(adt, convert(Vector{Nulls.T(T)}, rowinds))
 end
 
 function Base.view(adt::AbstractDataTable, rowinds::Any)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,3 @@
 Compat 0.9.0
 DataStructures
 LaTeXStrings
-CSV

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -40,8 +40,8 @@ module TestCat
         dt = DataTable()
         DataTables.hcat!(dt, NullableCategoricalVector(1:10))
         @test isequal(dt[1], NullableCategoricalVector(1:10))
-        DataTables.hcat!(dt, Vector(1:10))
-        @test isequal(dt[2], Vector(1:10))
+        DataTables.hcat!(dt, 1:10)
+        @test isequal(dt[2], 1:10)
     end
 
     #
@@ -248,7 +248,7 @@ module TestCat
         err = @test_throws ArgumentError vcat(dt1, dt2, dt3, dt4, dt1, dt2, dt3, dt4, dt1, dt2, dt3, dt4)
         @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 5 and 9, column(s) B are missing from argument(s) 2, 6 and 10, and column(s) F are missing from argument(s) 3, 7 and 11"
     end
-    x = view(DataTable(A = Vector(1:3)), 2)
-    y = DataTable(A = Vector(4:5))
+    x = view(DataTable(A = 1:3), 2)
+    y = DataTable(A = 4:5)
     @test isequal(vcat(x, y), DataTable(A = [2, 4, 5]))
 end

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -16,16 +16,16 @@ module TestCat
     dth = hcat(dt3, dt4)
     @test size(dth, 2) == 3
     @test names(dth) == [:x1, :x1_1, :x2]
-    @test isequal(dth[:x1], dt3[:x1])
-    @test isequal(dth, [dt3 dt4])
-    @test isequal(dth, DataTables.hcat!(DataTable(), dt3, dt4))
+    @test dth[:x1] == dt3[:x1]
+    @test dth == [dt3 dt4]
+    @test dth == DataTables.hcat!(DataTable(), dt3, dt4)
 
     dth3 = hcat(dt3, dt4, dt5)
     @test names(dth3) == [:x1, :x1_1, :x2, :x1_2, :x2_1]
-    @test isequal(dth3, hcat(dth, dt5))
-    @test isequal(dth3, DataTables.hcat!(DataTable(), dt3, dt4, dt5))
+    @test dth3 == hcat(dth, dt5)
+    @test dth3 == DataTables.hcat!(DataTable(), dt3, dt4, dt5)
 
-    @test isequal(dt2, DataTables.hcat!(dt2))
+    @test dt2 == DataTables.hcat!(dt2)
 
     @testset "hcat ::AbstractDataTable" begin
         dt = DataTable(A = repeat('A':'C', inner=4), B = 1:12)
@@ -39,9 +39,9 @@ module TestCat
     @testset "hcat ::Vectors" begin
         dt = DataTable()
         DataTables.hcat!(dt, NullableCategoricalVector(1:10))
-        @test isequal(dt[1], NullableCategoricalVector(1:10))
+        @test dt[1] == NullableCategoricalVector(1:10)
         DataTables.hcat!(dt, 1:10)
-        @test isequal(dt[2], 1:10)
+        @test dt[2] == collect(1:10)
     end
 
     #
@@ -107,7 +107,7 @@ module TestCat
     dtr = vcat(dt4, dt4)
     @test size(dtr, 1) == 8
     @test names(dt4) == names(dtr)
-    @test isequal(dtr, [dt4; dt4])
+    @test dtr == [dt4; dt4]
 
     @test eltypes(vcat(DataTable(a = [1]), DataTable(a = [2.1]))) == Type[Float64]
     @test eltypes(vcat(DataTable(a = nulls(?Int, 1)), DataTable(a = (?Float64)[2.1]))) == Type[?Float64]
@@ -119,21 +119,21 @@ module TestCat
     dtd = DataTable(Any[2:4], [:a])
     dtab = vcat(dta, dtb)
     dtac = vcat(dta, dtc)
-    @test isequal(dtab[:a], ?(Int)[1, 2, 2, 2, 3, 4])
-    @test isequal(dtac[:a], ?(Int)[1, 2, 2, 2, 3, 4])
+    @test dtab[:a] == [1, 2, 2, 2, 3, 4]
+    @test dtac[:a] == [1, 2, 2, 2, 3, 4]
     @test isa(dtab[:a], NullableCategoricalVector{Int})
     @test isa(dtac[:a], NullableCategoricalVector{Int})
     # ^^ container may flip if container promotion happens in Base/DataArrays
     dc = vcat(dtd, dtc)
-    @test isequal(vcat(dtc, dtd), dc)
+    @test vcat(dtc, dtd) == dc
 
     # Zero-row DataTables
     dtc0 = similar(dtc, 0)
-    @test isequal(vcat(dtd, dtc0, dtc), dc)
+    @test vcat(dtd, dtc0, dtc) == dc
     @test eltypes(vcat(dtd, dtc0)) == eltypes(dc)
 
     # vcat should be able to concatenate different implementations of AbstractDataTable (PR #944)
-    @test isequal(vcat(view(DataTable(A=1:3),2),DataTable(A=4:5)), DataTable(A=[2,4,5]))
+    @test vcat(view(DataTable(A=1:3),2),DataTable(A=4:5)) == DataTable(A=[2,4,5])
 
     @testset "vcat >2 args" begin
         @test vcat(DataTable(), DataTable(), DataTable()) == DataTable()
@@ -250,5 +250,5 @@ module TestCat
     end
     x = view(DataTable(A = 1:3), 2)
     y = DataTable(A = 4:5)
-    @test isequal(vcat(x, y), DataTable(A = [2, 4, 5]))
+    @test vcat(x, y) == DataTable(A = [2, 4, 5])
 end

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -5,13 +5,13 @@ module TestCat
     # hcat
     #
 
-    nvint = Vector(?(Int)[1, 2, null, 4])
-    nvstr = Vector(?(String)["one", "two", null, "four"])
+    nvint = [1, 2, null, 4]
+    nvstr = ["one", "two", null, "four"]
 
     dt2 = DataTable(Any[nvint, nvstr])
     dt3 = DataTable(Any[nvint])
     dt4 = convert(DataTable, [1:4 1:4])
-    dt5 = DataTable(Any[Vector([1,2,3,4]), nvstr])
+    dt5 = DataTable(Any[(?Int)[1,2,3,4], nvstr])
 
     dth = hcat(dt3, dt4)
     @test size(dth, 2) == 3
@@ -110,12 +110,12 @@ module TestCat
     @test isequal(dtr, [dt4; dt4])
 
     @test eltypes(vcat(DataTable(a = [1]), DataTable(a = [2.1]))) == Type[Float64]
-    @test eltypes(vcat(DataTable(a = Vector{Int}(1)), DataTable(a = [2.1]))) == Type[Float64]
+    @test eltypes(vcat(DataTable(a = nulls(?Int, 1)), DataTable(a = (?Float64)[2.1]))) == Type[?Float64]
 
     # Minimal container type promotion
     dta = DataTable(a = NullableCategoricalArray([1, 2, 2]))
     dtb = DataTable(a = NullableCategoricalArray([2, 3, 4]))
-    dtc = DataTable(a = Vector([2, 3, 4]))
+    dtc = DataTable(a = (?Int)[2, 3, 4])
     dtd = DataTable(Any[2:4], [:a])
     dtab = vcat(dta, dtb)
     dtac = vcat(dta, dtc)
@@ -149,23 +149,23 @@ module TestCat
         dt = vcat(DataTable([[1]], [:x]), DataTable([["1"]], [:x]))
         @test dt == DataTable([[1, "1"]], [:x])
         @test typeof.(dt.columns) == [Vector{Any}]
-        dt = vcat(DataTable([Vector([1])], [:x]), DataTable([[1]], [:x]))
-        @test dt == DataTable([Vector([1, 1])], [:x])
+        dt = vcat(DataTable([[1]], [:x]), DataTable([[1]], [:x]))
+        @test dt == DataTable([[1, 1]], [:x])
         @test typeof.(dt.columns) == [Vector{Int}]
         dt = vcat(DataTable([CategoricalArray([1])], [:x]), DataTable([[1]], [:x]))
         @test dt == DataTable([CategoricalArray([1, 1])], [:x])
         @test typeof.(dt.columns) == [CategoricalVector{Int, drf}]
         dt = vcat(DataTable([CategoricalArray([1])], [:x]),
-                  DataTable([Vector([1])], [:x]))
+                  DataTable([[1]], [:x]))
         @test dt == DataTable([CategoricalArray([1, 1])], [:x])
         @test typeof.(dt.columns) == [CategoricalVector{Int, drf}]
         dt = vcat(DataTable([CategoricalArray([1])], [:x]),
                   DataTable([NullableCategoricalArray([1])], [:x]))
         @test dt == DataTable([NullableCategoricalArray([1, 1])], [:x])
         @test typeof.(dt.columns) == [NullableCategoricalVector{Int, drf}]
-        dt = vcat(DataTable([Vector([1])], [:x]),
-                  DataTable([Vector(["1"])], [:x]))
-        @test dt == DataTable([Vector([1, "1"])], [:x])
+        dt = vcat(DataTable([[1]], [:x]),
+                  DataTable([["1"]], [:x]))
+        @test dt == DataTable([[1, "1"]], [:x])
         @test typeof.(dt.columns) == [Vector{Any}]
         dt = vcat(DataTable([CategoricalArray([1])], [:x]),
                   DataTable([CategoricalArray(["1"])], [:x]))
@@ -250,5 +250,5 @@ module TestCat
     end
     x = view(DataTable(A = Vector(1:3)), 2)
     y = DataTable(A = Vector(4:5))
-    @test isequal(vcat(x, y), DataTable(A = Vector([2, 4, 5])))
+    @test isequal(vcat(x, y), DataTable(A = [2, 4, 5]))
 end

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -148,27 +148,27 @@ module TestCat
         dt = vcat(DataTable([[1]], [:x]), DataTable([["1"]], [:x]))
         @test dt == DataTable([[1, "1"]], [:x])
         @test typeof.(dt.columns) == [Vector{Any}]
-        dt = vcat(DataTable([[1]], [:x]), DataTable([[1]], [:x]))
+        dt = vcat(DataTable([Union{Null, Int}[1]], [:x]), DataTable([[1]], [:x]))
         @test dt == DataTable([[1, 1]], [:x])
-        @test typeof.(dt.columns) == [Vector{Int}]
+        @test typeof.(dt.columns) == [Vector{Union{Null, Int}}]
         dt = vcat(DataTable([CategoricalArray([1])], [:x]), DataTable([[1]], [:x]))
-        @test dt == DataTable([CategoricalArray([1, 1])], [:x])
+        @test dt == DataTable([[1, 1]], [:x])
         @test typeof(dt[:x]) <: CategoricalVector{Int}
         dt = vcat(DataTable([CategoricalArray([1])], [:x]),
-                  DataTable([[1]], [:x]))
-        @test dt == DataTable([CategoricalArray([1, 1])], [:x])
-        @test typeof(dt[:x]) <: CategoricalVector{Int}
+                  DataTable([Union{Null, Int}[1]], [:x]))
+        @test dt == DataTable([[1, 1]], [:x])
+        @test typeof(dt[:x]) <: CategoricalVector{Union{Int, Null}}
         dt = vcat(DataTable([CategoricalArray([1])], [:x]),
                   DataTable([CategoricalArray{Union{Int, Null}}([1])], [:x]))
-        @test dt == DataTable([CategoricalArray{Union{Int, Null}}([1, 1])], [:x])
+        @test dt == DataTable([[1, 1]], [:x])
         @test typeof(dt[:x]) <: CategoricalVector{Union{Int, Null}}
-        dt = vcat(DataTable([[1]], [:x]),
+        dt = vcat(DataTable([Union{Int, Null}[1]], [:x]),
                   DataTable([["1"]], [:x]))
         @test dt == DataTable([[1, "1"]], [:x])
         @test typeof.(dt.columns) == [Vector{Any}]
         dt = vcat(DataTable([CategoricalArray([1])], [:x]),
                   DataTable([CategoricalArray(["1"])], [:x]))
-        @test dt == DataTable([CategoricalArray([1, "1"])], [:x])
+        @test dt == DataTable([[1, "1"]], [:x])
         @test typeof(dt[:x]) <: CategoricalVector{Any}
         dt = vcat(DataTable([trues(1)], [:x]), DataTable([[false]], [:x]))
         @test dt == DataTable([[true, false]], [:x])
@@ -247,7 +247,7 @@ module TestCat
         err = @test_throws ArgumentError vcat(dt1, dt2, dt3, dt4, dt1, dt2, dt3, dt4, dt1, dt2, dt3, dt4)
         @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 5 and 9, column(s) B are missing from argument(s) 2, 6 and 10, and column(s) F are missing from argument(s) 3, 7 and 11"
     end
-    x = view(DataTable(A = 1:3), 2)
+    x = view(DataTable(A = Vector{Union{Null, Int}}(1:3)), 2)
     y = DataTable(A = 4:5)
     @test vcat(x, y) == DataTable(A = [2, 4, 5])
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -21,17 +21,17 @@ module TestConstructors
                                 x2 = Vector([1.0, 1.0, 1.0])))
 
     dt2 = convert(DataTable, Matrix([0.0 1.0;
-                                            0.0 1.0;
-                                            0.0 1.0]))
+                                     0.0 1.0;
+                                     0.0 1.0]))
     names!(dt2, [:x1, :x2])
     @test isequal(dt[:x1], Vector(dt2[:x1]))
     @test isequal(dt[:x2], Vector(dt2[:x2]))
 
-    @test isequal(dt, DataTable(x1 = Vector([0.0, 0.0, 0.0]),
-                                x2 = Vector([1.0, 1.0, 1.0])))
-    @test isequal(dt, DataTable(x1 = Vector([0.0, 0.0, 0.0]),
-                                x2 = Vector([1.0, 1.0, 1.0]),
-                                x3 = Vector([2.0, 2.0, 2.0]))[[:x1, :x2]])
+    @test isequal(dt, DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
+                                x2 = (?Float64)[1.0, 1.0, 1.0]))
+    @test isequal(dt, DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
+                                x2 = (?Float64)[1.0, 1.0, 1.0],
+                                x3 = (?Float64)[2.0, 2.0, 2.0])[[:x1, :x2]])
 
     dt = DataTable(?(Int), 2, 2)
     @test size(dt) == (2, 2)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,6 +1,5 @@
 module TestConstructors
-    using Base.Test
-    using DataTables, DataTables.Index, Nulls
+    using Base.Test, DataTables, Nulls, DataTables.Index
 
     #
     # DataTable

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,6 +1,6 @@
 module TestConstructors
     using Base.Test
-    using DataTables, DataTables.Index
+    using DataTables, DataTables.Index, Nulls
 
     #
     # DataTable
@@ -18,31 +18,31 @@ module TestConstructors
 
     @test isequal(dt, DataTable(Any[NullableCategoricalVector(zeros(3)),
                                     NullableCategoricalVector(ones(3))]))
-    @test isequal(dt, DataTable(x1 = NullableArray([0.0, 0.0, 0.0]),
-                                x2 = NullableArray([1.0, 1.0, 1.0])))
+    @test isequal(dt, DataTable(x1 = Vector([0.0, 0.0, 0.0]),
+                                x2 = Vector([1.0, 1.0, 1.0])))
 
-    dt2 = convert(DataTable, NullableArray([0.0 1.0;
+    dt2 = convert(DataTable, Matrix([0.0 1.0;
                                             0.0 1.0;
                                             0.0 1.0]))
     names!(dt2, [:x1, :x2])
-    @test isequal(dt[:x1], NullableArray(dt2[:x1]))
-    @test isequal(dt[:x2], NullableArray(dt2[:x2]))
+    @test isequal(dt[:x1], Vector(dt2[:x1]))
+    @test isequal(dt[:x2], Vector(dt2[:x2]))
 
-    @test isequal(dt, DataTable(x1 = NullableArray([0.0, 0.0, 0.0]),
-                                x2 = NullableArray([1.0, 1.0, 1.0])))
-    @test isequal(dt, DataTable(x1 = NullableArray([0.0, 0.0, 0.0]),
-                                x2 = NullableArray([1.0, 1.0, 1.0]),
-                                x3 = NullableArray([2.0, 2.0, 2.0]))[[:x1, :x2]])
+    @test isequal(dt, DataTable(x1 = Vector([0.0, 0.0, 0.0]),
+                                x2 = Vector([1.0, 1.0, 1.0])))
+    @test isequal(dt, DataTable(x1 = Vector([0.0, 0.0, 0.0]),
+                                x2 = Vector([1.0, 1.0, 1.0]),
+                                x3 = Vector([2.0, 2.0, 2.0]))[[:x1, :x2]])
 
-    dt = DataTable(Nullable{Int}, 2, 2)
+    dt = DataTable(?(Int), 2, 2)
     @test size(dt) == (2, 2)
-    @test eltypes(dt) == [Nullable{Int}, Nullable{Int}]
+    @test eltypes(dt) == [?(Int), ?(Int)]
 
-    dt = DataTable([Nullable{Int}, Nullable{Float64}], [:x1, :x2], 2)
+    dt = DataTable([?(Int), ?(Float64)], [:x1, :x2], 2)
     @test size(dt) == (2, 2)
-    @test eltypes(dt) == [Nullable{Int}, Nullable{Float64}]
+    @test eltypes(dt) == [?(Int), ?(Float64)]
 
-    @test isequal(dt, DataTable([Nullable{Int}, Nullable{Float64}], 2))
+    @test isequal(dt, DataTable([?(Int), ?(Float64)], 2))
 
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
@@ -75,8 +75,8 @@ module TestConstructors
         dt = DataTable(A = 1:3, B = 2:4, C = 3:5)
         answer = [Array{Int,1}, Array{Int,1}, Array{Int,1}]
         @test map(typeof, dt.columns) == answer
-        dt[:D] = NullableArray([4, 5, Nullable()])
-        push!(answer, NullableArray{Int,1})
+        dt[:D] = Vector([4, 5, null])
+        push!(answer, Vector{?Int})
         @test map(typeof, dt.columns) == answer
         dt[:E] = 'c'
         push!(answer, Array{Char,1})

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -17,12 +17,12 @@ module TestConstructors
 
     @test dt == DataTable(Any[CategoricalVector{Union{Float64, Null}}(zeros(3)),
                               CategoricalVector{Union{Float64, Null}}(ones(3))])
-    @test dt == DataTable(x1 = [0.0, 0.0, 0.0],
-                          x2 = [1.0, 1.0, 1.0])
+    @test dt == DataTable(x1 = Union{Int, Null}[0.0, 0.0, 0.0],
+                          x2 = Union{Int, Null}[1.0, 1.0, 1.0])
 
-    dt2 = convert(DataTable, Matrix([0.0 1.0;
-                                     0.0 1.0;
-                                     0.0 1.0]))
+    dt2 = convert(DataTable, Union{Float64, Null}[0.0 1.0;
+                                                  0.0 1.0;
+                                                  0.0 1.0])
     names!(dt2, [:x1, :x2])
     @test dt[:x1] == dt2[:x1]
     @test dt[:x2] == dt2[:x2]

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -6,8 +6,8 @@ module TestConstructors
     #
 
     dt = DataTable()
-    @test isequal(dt.columns, Any[])
-    @test isequal(dt.colindex, Index())
+    @test dt.columns == Any[]
+    @test dt.colindex == Index()
 
     dt = DataTable(Any[NullableCategoricalVector(zeros(3)),
                        NullableCategoricalVector(ones(3))],
@@ -15,10 +15,10 @@ module TestConstructors
     @test size(dt, 1) == 3
     @test size(dt, 2) == 2
 
-    @test isequal(dt, DataTable(Any[NullableCategoricalVector(zeros(3)),
-                                    NullableCategoricalVector(ones(3))]))
-    @test isequal(dt, DataTable(x1 = [0.0, 0.0, 0.0],
-                                x2 = [1.0, 1.0, 1.0]))
+    @test dt == DataTable(Any[NullableCategoricalVector(zeros(3)),
+                              NullableCategoricalVector(ones(3))])
+    @test dt == DataTable(x1 = [0.0, 0.0, 0.0],
+                          x2 = [1.0, 1.0, 1.0])
 
     dt2 = convert(DataTable, Matrix([0.0 1.0;
                                      0.0 1.0;
@@ -27,28 +27,28 @@ module TestConstructors
     @test dt[:x1] == dt2[:x1]
     @test dt[:x2] == dt2[:x2]
 
-    @test isequal(dt, DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
-                                x2 = (?Float64)[1.0, 1.0, 1.0]))
-    @test isequal(dt, DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
-                                x2 = (?Float64)[1.0, 1.0, 1.0],
-                                x3 = (?Float64)[2.0, 2.0, 2.0])[[:x1, :x2]])
+    @test dt == DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
+                          x2 = (?Float64)[1.0, 1.0, 1.0])
+    @test dt == DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
+                          x2 = (?Float64)[1.0, 1.0, 1.0],
+                          x3 = (?Float64)[2.0, 2.0, 2.0])[[:x1, :x2]]
 
-    dt = DataTable(?(Int), 2, 2)
+    dt = DataTable((?Int), 2, 2)
     @test size(dt) == (2, 2)
     @test eltypes(dt) == [?(Int), ?(Int)]
 
-    dt = DataTable([?(Int), ?(Float64)], [:x1, :x2], 2)
+    dt = DataTable([?Int, ?Float64], [:x1, :x2], 2)
     @test size(dt) == (2, 2)
-    @test eltypes(dt) == [?(Int), ?(Float64)]
+    @test eltypes(dt) == [?Int, ?Float64]
 
-    @test isequal(dt, DataTable([?(Int), ?(Float64)], 2))
+    @test dt == DataTable([?Int, ?Float64], 2)
 
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
-    @test isequal(SubDataTable(DataTable(A=1), 1), DataTable(A=1))
-    @test isequal(SubDataTable(DataTable(A=1:10), 1:4), DataTable(A=1:4))
-    @test isequal(view(SubDataTable(DataTable(A=1:10), 1:4), 2), DataTable(A=2))
-    @test isequal(view(SubDataTable(DataTable(A=1:10), 1:4), [true, true, false, false]), DataTable(A=1:2))
+    @test SubDataTable(DataTable(A=1), 1) == DataTable(A=1)
+    @test SubDataTable(DataTable(A=1:10), 1:4) == DataTable(A=1:4)
+    @test view(SubDataTable(DataTable(A=1:10), 1:4), 2) == DataTable(A=2)
+    @test view(SubDataTable(DataTable(A=1:10), 1:4), [true, true, false, false]) == DataTable(A=1:2)
 
     @test DataTable(a=1, b=1:2) == DataTable(a=[1,1], b=[1,2])
 

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -17,15 +17,15 @@ module TestConstructors
 
     @test isequal(dt, DataTable(Any[NullableCategoricalVector(zeros(3)),
                                     NullableCategoricalVector(ones(3))]))
-    @test isequal(dt, DataTable(x1 = Vector([0.0, 0.0, 0.0]),
-                                x2 = Vector([1.0, 1.0, 1.0])))
+    @test isequal(dt, DataTable(x1 = [0.0, 0.0, 0.0],
+                                x2 = [1.0, 1.0, 1.0]))
 
     dt2 = convert(DataTable, Matrix([0.0 1.0;
                                      0.0 1.0;
                                      0.0 1.0]))
     names!(dt2, [:x1, :x2])
-    @test isequal(dt[:x1], Vector(dt2[:x1]))
-    @test isequal(dt[:x2], Vector(dt2[:x2]))
+    @test dt[:x1] == dt2[:x1]
+    @test dt[:x2] == dt2[:x2]
 
     @test isequal(dt, DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
                                 x2 = (?Float64)[1.0, 1.0, 1.0]))
@@ -74,11 +74,11 @@ module TestConstructors
         dt = DataTable(A = 1:3, B = 2:4, C = 3:5)
         answer = [Array{Int,1}, Array{Int,1}, Array{Int,1}]
         @test map(typeof, dt.columns) == answer
-        dt[:D] = Vector([4, 5, null])
+        dt[:D] = [4, 5, null]
         push!(answer, Vector{?Int})
         @test map(typeof, dt.columns) == answer
         dt[:E] = 'c'
-        push!(answer, Array{Char,1})
+        push!(answer, Vector{Char})
         @test map(typeof, dt.columns) == answer
     end
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -33,9 +33,9 @@ module TestConstructors
                           x2 = (?Float64)[1.0, 1.0, 1.0],
                           x3 = (?Float64)[2.0, 2.0, 2.0])[[:x1, :x2]]
 
-    dt = DataTable((?Int), 2, 2)
+    dt = DataTable(?Int, 2, 2)
     @test size(dt) == (2, 2)
-    @test eltypes(dt) == [?(Int), ?(Int)]
+    @test eltypes(dt) == [?Int, ?Int]
 
     dt = DataTable([?Int, ?Float64], [:x1, :x2], 2)
     @test size(dt) == (2, 2)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,5 +1,5 @@
 module TestConstructors
-    using Base.Test, DataTables, Nulls, DataTables.Index
+    using Base.Test, DataTables, DataTables.Index
 
     #
     # DataTable
@@ -9,14 +9,14 @@ module TestConstructors
     @test dt.columns == Any[]
     @test dt.colindex == Index()
 
-    dt = DataTable(Any[NullableCategoricalVector(zeros(3)),
-                       NullableCategoricalVector(ones(3))],
+    dt = DataTable(Any[CategoricalVector{Union{Float64, Null}}(zeros(3)),
+                       CategoricalVector{Union{Float64, Null}}(ones(3))],
                    Index([:x1, :x2]))
     @test size(dt, 1) == 3
     @test size(dt, 2) == 2
 
-    @test dt == DataTable(Any[NullableCategoricalVector(zeros(3)),
-                              NullableCategoricalVector(ones(3))])
+    @test dt == DataTable(Any[CategoricalVector{Union{Float64, Null}}(zeros(3)),
+                              CategoricalVector{Union{Float64, Null}}(ones(3))])
     @test dt == DataTable(x1 = [0.0, 0.0, 0.0],
                           x2 = [1.0, 1.0, 1.0])
 
@@ -27,21 +27,21 @@ module TestConstructors
     @test dt[:x1] == dt2[:x1]
     @test dt[:x2] == dt2[:x2]
 
-    @test dt == DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
-                          x2 = (?Float64)[1.0, 1.0, 1.0])
-    @test dt == DataTable(x1 = (?Float64)[0.0, 0.0, 0.0],
-                          x2 = (?Float64)[1.0, 1.0, 1.0],
-                          x3 = (?Float64)[2.0, 2.0, 2.0])[[:x1, :x2]]
+    @test dt == DataTable(x1 = Union{Float64, Null}[0.0, 0.0, 0.0],
+                          x2 = Union{Float64, Null}[1.0, 1.0, 1.0])
+    @test dt == DataTable(x1 = Union{Float64, Null}[0.0, 0.0, 0.0],
+                          x2 = Union{Float64, Null}[1.0, 1.0, 1.0],
+                          x3 = Union{Float64, Null}[2.0, 2.0, 2.0])[[:x1, :x2]]
 
-    dt = DataTable(?Int, 2, 2)
+    dt = DataTable(Union{Int, Null}, 2, 2)
     @test size(dt) == (2, 2)
-    @test eltypes(dt) == [?Int, ?Int]
+    @test eltypes(dt) == [Union{Int, Null}, Union{Int, Null}]
 
-    dt = DataTable([?Int, ?Float64], [:x1, :x2], 2)
+    dt = DataTable([Union{Int, Null}, Union{Float64, Null}], [:x1, :x2], 2)
     @test size(dt) == (2, 2)
-    @test eltypes(dt) == [?Int, ?Float64]
+    @test eltypes(dt) == [Union{Int, Null}, Union{Float64, Null}]
 
-    @test dt == DataTable([?Int, ?Float64], 2)
+    @test dt == DataTable([Union{Int, Null}, Union{Float64, Null}], 2)
 
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
     @test_throws BoundsError SubDataTable(DataTable(A=1), 0)
@@ -75,7 +75,7 @@ module TestConstructors
         answer = [Array{Int,1}, Array{Int,1}, Array{Int,1}]
         @test map(typeof, dt.columns) == answer
         dt[:D] = [4, 5, null]
-        push!(answer, Vector{?Int})
+        push!(answer, Vector{Union{Int, Null}})
         @test map(typeof, dt.columns) == answer
         dt[:E] = 'c'
         push!(answer, Vector{Char})

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -16,8 +16,8 @@ module TestConversions
     @test isa(convert(Array{Float64}, dt), Matrix{Float64})
 
     dt = DataTable()
-    dt[:A] = Vector(1.0:5.0)
-    dt[:B] = Vector(1.0:5.0)
+    dt[:A] = 1.0:5.0
+    dt[:B] = 1.0:5.0
     a = convert(Array, dt)
     aa = convert(Array{Any}, dt)
     ai = convert(Array{Int}, dt)
@@ -41,33 +41,33 @@ module TestConversions
     @test isa(nai, Matrix{?Int})
     @test isequal(nai, convert(Matrix{?Int}, dt))
 
-    a = Vector([1.0,2.0])
-    b = Vector([-0.1,3])
-    c = Vector([-3.1,7])
+    a = [1.0,2.0]
+    b = [-0.1,3]
+    c = [-3.1,7]
     di = Dict("a"=>a, "b"=>b, "c"=>c)
 
     dt = convert(DataTable, di)
     @test isa(dt, DataTable)
     @test names(dt) == Symbol[x for x in sort(collect(keys(di)))]
-    @test isequal(dt[:a], Vector(a))
-    @test isequal(dt[:b], Vector(b))
-    @test isequal(dt[:c], Vector(c))
+    @test dt[:a] == a
+    @test dt[:b] == b
+    @test dt[:c] == c
 
     od = OrderedDict("c"=>c, "a"=>a, "b"=>b)
     dt = convert(DataTable,od)
     @test isa(dt, DataTable)
     @test names(dt) == Symbol[x for x in keys(od)]
-    @test isequal(dt[:a], Vector(a))
-    @test isequal(dt[:b], Vector(b))
-    @test isequal(dt[:c], Vector(c))
+    @test dt[:a] == a
+    @test dt[:b] == b
+    @test dt[:c] == c
 
     sd = SortedDict("c"=>c, "a"=>a, "b"=>b)
     dt = convert(DataTable,sd)
     @test isa(dt, DataTable)
     @test names(dt) == Symbol[x for x in keys(sd)]
-    @test isequal(dt[:a], Vector(a))
-    @test isequal(dt[:b], Vector(b))
-    @test isequal(dt[:c], Vector(c))
+    @test dt[:a] == a
+    @test dt[:b] == b
+    @test dt[:c] == c
 
     a = [1.0]
     di = Dict("a"=>a, "b"=>b, "c"=>c)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,79 +1,74 @@
 module TestConversions
     using Base.Test
-    using DataTables
+    using DataTables, Nulls
     using DataStructures: OrderedDict, SortedDict
 
     dt = DataTable()
     dt[:A] = 1:5
     dt[:B] = [:A, :B, :C, :D, :E]
     @test isa(convert(Array, dt), Matrix{Any})
-    @test convert(Array, dt) == convert(Array, convert(NullableArray, dt))
     @test isa(convert(Array{Any}, dt), Matrix{Any})
 
     dt = DataTable()
     dt[:A] = 1:5
     dt[:B] = 1.0:5.0
-    # Fails on Julia 0.4 since promote_type(Nullable{Int}, Nullable{Float64}) gives Nullable{T}
-    if VERSION >= v"0.5.0-dev"
-        @test isa(convert(Array, dt), Matrix{Float64})
-    end
-    @test convert(Array, dt) == convert(Array, convert(NullableArray, dt))
+    @test isa(convert(Array, dt), Matrix{Float64})
     @test isa(convert(Array{Any}, dt), Matrix{Any})
     @test isa(convert(Array{Float64}, dt), Matrix{Float64})
 
     dt = DataTable()
-    dt[:A] = NullableArray(1.0:5.0)
-    dt[:B] = NullableArray(1.0:5.0)
+    dt[:A] = Vector(1.0:5.0)
+    dt[:B] = Vector(1.0:5.0)
     a = convert(Array, dt)
     aa = convert(Array{Any}, dt)
     ai = convert(Array{Int}, dt)
     @test isa(a, Matrix{Float64})
-    @test a == convert(Array, convert(NullableArray, dt))
     @test a == convert(Matrix, dt)
     @test isa(aa, Matrix{Any})
     @test aa == convert(Matrix{Any}, dt)
     @test isa(ai, Matrix{Int})
     @test ai == convert(Matrix{Int}, dt)
 
-    dt[1,1] = Nullable()
-    @test_throws ErrorException convert(Array, dt)
-    na = convert(NullableArray, dt)
-    naa = convert(NullableArray{Any}, dt)
-    nai = convert(NullableArray{Int}, dt)
-    @test isa(na, NullableMatrix{Float64})
-    @test isequal(na, convert(NullableMatrix, dt))
-    @test isa(naa, NullableMatrix{Any})
-    @test isequal(naa, convert(NullableMatrix{Any}, dt))
-    @test isa(nai, NullableMatrix{Int})
-    @test isequal(nai, convert(NullableMatrix{Int}, dt))
+    @test_throws MethodError dt[1,1] = null
+    dt[:A] = Vector{?Float64}(1.0:5.0)
+    dt[1, 1] = null
+    na = convert(Array{?Float64}, dt)
+    naa = convert(Array{?Any}, dt)
+    nai = convert(Array{?Int}, dt)
+    @test isa(na, Matrix{?Float64})
+    @test isequal(na, convert(Matrix, dt))
+    @test isa(naa, Matrix{?Any})
+    @test isequal(naa, convert(Matrix{?Any}, dt))
+    @test isa(nai, Matrix{?Int})
+    @test isequal(nai, convert(Matrix{?Int}, dt))
 
-    a = NullableArray([1.0,2.0])
-    b = NullableArray([-0.1,3])
-    c = NullableArray([-3.1,7])
+    a = Vector([1.0,2.0])
+    b = Vector([-0.1,3])
+    c = Vector([-3.1,7])
     di = Dict("a"=>a, "b"=>b, "c"=>c)
 
-    dt = convert(DataTable,di)
-    @test isa(dt,DataTable)
+    dt = convert(DataTable, di)
+    @test isa(dt, DataTable)
     @test names(dt) == Symbol[x for x in sort(collect(keys(di)))]
-    @test isequal(dt[:a], NullableArray(a))
-    @test isequal(dt[:b], NullableArray(b))
-    @test isequal(dt[:c], NullableArray(c))
+    @test isequal(dt[:a], Vector(a))
+    @test isequal(dt[:b], Vector(b))
+    @test isequal(dt[:c], Vector(c))
 
     od = OrderedDict("c"=>c, "a"=>a, "b"=>b)
     dt = convert(DataTable,od)
     @test isa(dt, DataTable)
     @test names(dt) == Symbol[x for x in keys(od)]
-    @test isequal(dt[:a], NullableArray(a))
-    @test isequal(dt[:b], NullableArray(b))
-    @test isequal(dt[:c], NullableArray(c))
+    @test isequal(dt[:a], Vector(a))
+    @test isequal(dt[:b], Vector(b))
+    @test isequal(dt[:c], Vector(c))
 
     sd = SortedDict("c"=>c, "a"=>a, "b"=>b)
     dt = convert(DataTable,sd)
     @test isa(dt, DataTable)
     @test names(dt) == Symbol[x for x in keys(sd)]
-    @test isequal(dt[:a], NullableArray(a))
-    @test isequal(dt[:b], NullableArray(b))
-    @test isequal(dt[:c], NullableArray(c))
+    @test isequal(dt[:a], Vector(a))
+    @test isequal(dt[:b], Vector(b))
+    @test isequal(dt[:c], Vector(c))
 
     a = [1.0]
     di = Dict("a"=>a, "b"=>b, "c"=>c)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -16,21 +16,21 @@ module TestConversions
     @test isa(convert(Array{Float64}, dt), Matrix{Float64})
 
     dt = DataTable()
-    dt[:A] = collect(1.0:5.0)
-    dt[:B] = collect(1.0:5.0)
+    dt[:A] = Vector{Union{Float64, Null}}(1.0:5.0)
+    dt[:B] = Vector{Union{Float64, Null}}(1.0:5.0)
     a = convert(Array, dt)
     aa = convert(Array{Any}, dt)
     ai = convert(Array{Int}, dt)
-    @test isa(a, Matrix{Float64})
+    @test isa(a, Matrix{Union{Float64, Null}})
+    @test a == convert(Array, convert(Array{Union{Float64, Null}}, dt))
     @test a == convert(Matrix, dt)
     @test isa(aa, Matrix{Any})
     @test aa == convert(Matrix{Any}, dt)
     @test isa(ai, Matrix{Int})
     @test ai == convert(Matrix{Int}, dt)
 
-    @test_throws MethodError dt[1,1] = null
-    dt[:A] = Vector{Union{Float64, Null}}(1.0:5.0)
-    dt[1, 1] = null
+    dt[1,1] = null
+    @test_throws ErrorException convert(Array{Float64}, dt)
     na = convert(Array{Union{Float64, Null}}, dt)
     naa = convert(Array{Union{Any, Null}}, dt)
     nai = convert(Array{Union{Int, Null}}, dt)
@@ -41,9 +41,9 @@ module TestConversions
     @test isa(nai, Matrix{Union{Int, Null}})
     @test nai == convert(Matrix{Union{Int, Null}}, dt)
 
-    a = [1.0,2.0]
-    b = [-0.1,3]
-    c = [-3.1,7]
+    a = Union{Float64, Null}[1.0,2.0]
+    b = Union{Float64, Null}[-0.1,3]
+    c = Union{Float64, Null}[-3.1,7]
     di = Dict("a"=>a, "b"=>b, "c"=>c)
 
     dt = convert(DataTable, di)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,6 +1,5 @@
 module TestConversions
-    using Base.Test
-    using DataTables, Nulls
+    using Base.Test, DataTables, Nulls
     using DataStructures: OrderedDict, SortedDict
 
     dt = DataTable()

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,5 +1,5 @@
 module TestConversions
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
     using DataStructures: OrderedDict, SortedDict
 
     dt = DataTable()
@@ -29,17 +29,17 @@ module TestConversions
     @test ai == convert(Matrix{Int}, dt)
 
     @test_throws MethodError dt[1,1] = null
-    dt[:A] = Vector{?Float64}(1.0:5.0)
+    dt[:A] = Vector{Union{Float64, Null}}(1.0:5.0)
     dt[1, 1] = null
-    na = convert(Array{?Float64}, dt)
-    naa = convert(Array{?Any}, dt)
-    nai = convert(Array{?Int}, dt)
-    @test isa(na, Matrix{?Float64})
+    na = convert(Array{Union{Float64, Null}}, dt)
+    naa = convert(Array{Union{Any, Null}}, dt)
+    nai = convert(Array{Union{Int, Null}}, dt)
+    @test isa(na, Matrix{Union{Float64, Null}})
     @test na == convert(Matrix, dt)
-    @test isa(naa, Matrix{?Any})
-    @test naa == convert(Matrix{?Any}, dt)
-    @test isa(nai, Matrix{?Int})
-    @test nai == convert(Matrix{?Int}, dt)
+    @test isa(naa, Matrix{Union{Any, Null}})
+    @test naa == convert(Matrix{Union{Any, Null}}, dt)
+    @test isa(nai, Matrix{Union{Int, Null}})
+    @test nai == convert(Matrix{Union{Int, Null}}, dt)
 
     a = [1.0,2.0]
     b = [-0.1,3]

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -16,8 +16,8 @@ module TestConversions
     @test isa(convert(Array{Float64}, dt), Matrix{Float64})
 
     dt = DataTable()
-    dt[:A] = 1.0:5.0
-    dt[:B] = 1.0:5.0
+    dt[:A] = collect(1.0:5.0)
+    dt[:B] = collect(1.0:5.0)
     a = convert(Array, dt)
     aa = convert(Array{Any}, dt)
     ai = convert(Array{Int}, dt)
@@ -35,11 +35,11 @@ module TestConversions
     naa = convert(Array{?Any}, dt)
     nai = convert(Array{?Int}, dt)
     @test isa(na, Matrix{?Float64})
-    @test isequal(na, convert(Matrix, dt))
+    @test na == convert(Matrix, dt)
     @test isa(naa, Matrix{?Any})
-    @test isequal(naa, convert(Matrix{?Any}, dt))
+    @test naa == convert(Matrix{?Any}, dt)
     @test isa(nai, Matrix{?Int})
-    @test isequal(nai, convert(Matrix{?Int}, dt))
+    @test nai == convert(Matrix{?Int}, dt)
 
     a = [1.0,2.0]
     b = [-0.1,3]

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,7 +1,6 @@
 module TestData
+    using Base.Test, DataTables, Nulls
     importall Base # so that we get warnings for conflicts
-    using Base.Test
-    using DataTables, Nulls
 
     #test_group("Vector creation")
     nvint = ?(Int)[1, 2, null, 4]

--- a/test/data.jl
+++ b/test/data.jl
@@ -3,23 +3,23 @@ module TestData
     importall Base # so that we get warnings for conflicts
 
     #test_group("Vector creation")
-    nvint = ?(Int)[1, 2, null, 4]
-    nvint2 = Vector(5:8)
-    nvint3 = Vector(5:8)
-    nvflt = ?(Float64)[1.0, 2.0, null, 4.0]
-    nvstr = ?(String)["one", "two", null, "four"]
+    nvint = [1, 2, null, 4]
+    nvint2 = 5:8
+    nvint3 = 5:8
+    nvflt = [1.0, 2.0, null, 4.0]
+    nvstr = ["one", "two", null, "four"]
     dvdict = Vector{Dict}(4)    # for issue #199
 
     #test_group("constructors")
     dt1 = DataTable(Any[nvint, nvstr], [:Ints, :Strs])
     dt2 = DataTable(Any[nvint, nvstr])
     dt3 = DataTable(Any[nvint])
-    dt4 = DataTable(Any[Vector(1:4), Vector(1:4)])
-    dt5 = DataTable(Any[Vector([1,2,3,4]), nvstr])
+    dt4 = DataTable(Any[1:4, 1:4])
+    dt5 = DataTable(Any[[1,2,3,4], nvstr])
     dt6 = DataTable(Any[nvint, nvint, nvstr], [:A, :B, :C])
     dt7 = DataTable(x = nvint, y = nvstr)
     @test size(dt7) == (4, 2)
-    @test isequal(dt7[:x], nvint)
+    @test dt7[:x] == nvint
 
     #test_group("description functions")
     @test size(dt6, 1) == 4
@@ -29,10 +29,10 @@ module TestData
     @test names(dt7) == [:x, :y]
 
     #test_group("ref")
-    @test isequal(dt6[2, 3], "two")
+    @test dt6[2, 3] == "two"
     @test isnull(dt6[3, 3])
-    @test isequal(dt6[2, :C], "two")
-    @test isequal(dt6[:B], nvint)
+    @test dt6[2, :C] == "two"
+    @test dt6[:B] == nvint
     @test size(dt6[[2,3]], 2) == 2
     @test size(dt6[2,:], 1) == 1
     @test size(dt6[[1, 3], [1, 3]]) == (2, 2)
@@ -41,12 +41,12 @@ module TestData
     # lots more to do
 
     #test_group("assign")
-    dt6[3] = Vector(["un", "deux", "trois", "quatre"])
-    @test isequal(dt6[1, 3], "un")
-    dt6[:B] = Vector([4, 3, 2, 1])
-    @test isequal(dt6[1,2], 4)
-    dt6[:D] = Vector([true, false, true, false])
-    @test isequal(dt6[1,4], true)
+    dt6[3] = ["un", "deux", "trois", "quatre"]
+    @test dt6[1, 3] == "un"
+    dt6[:B] = [4, 3, 2, 1]
+    @test dt6[1,2] == 4
+    dt6[:D] = [true, false, true, false]
+    @test dt6[1,4]
     delete!(dt6, :D)
     @test names(dt6) == [:A, :B, :C]
     @test size(dt6, 2) == 3
@@ -72,7 +72,7 @@ module TestData
     @test size(sdt6d) == (2,1)
 
     #test_group("ref")
-    @test isequal(sdt6a[1,2], 4)
+    @test sdt6a[1,2] == 4
 
     #test_context("Within")
     #test_group("Associative")
@@ -81,50 +81,50 @@ module TestData
     srand(1)
     N = 20
     #Cast to Int64 as rand() behavior differs between Int32/64
-    d1 = Vector(rand(map(Int64, 1:2), N))
+    d1 = rand(map(Int64, 1:2), N)
     d2 = NullableCategoricalArray(?(String)["A", "B", null])[rand(map(Int64, 1:3), N)]
-    d3 = Vector(randn(N))
-    d4 = Vector(randn(N))
+    d3 = randn(N)
+    d4 = randn(N)
     dt7 = DataTable(Any[d1, d2, d3], [:d1, :d2, :d3])
 
     #test_group("groupby")
     gd = groupby(dt7, :d1)
     @test length(gd) == 2
     # @test isequal(gd[2]["d2"], CategoricalVector["A", "B", null, "A", null, null, null, null])
-    @test isequal(sum(gd[2][:d3]), sum(dt7[:d3][Vector(dt7[:d1]) .== 2]))
+    @test sum(gd[2][:d3]) == sum(dt7[:d3][dt7[:d1] .== 2])
 
     g1 = groupby(dt7, [:d1, :d2])
     g2 = groupby(dt7, [:d2, :d1])
-    @test isequal(sum(g1[1][:d3]), sum(g2[1][:d3]))
+    @test sum(g1[1][:d3]) == sum(g2[1][:d3])
 
     res = 0.0
     for x in g1
         res += sum(x[:d1])
     end
-    @test isequal(res, sum(dt7[:d1]))
+    @test res == sum(dt7[:d1])
 
     @test aggregate(DataTable(a=1), identity) == DataTable(a_identity=1)
 
     dt8 = aggregate(dt7[[1, 3]], sum)
-    @test isequal(dt8[1, :d1_sum], sum(dt7[:d1]))
+    @test dt8[1, :d1_sum] == sum(dt7[:d1])
 
     dt8 = aggregate(dt7, :d2, [sum, length], sort=true)
-    @test isequal(dt8[1:2, :d2], NullableCategoricalArray(["A", "B"]))
+    @test dt8[1:2, :d2] == NullableCategoricalArray(["A", "B"])
     @test size(dt8, 1) == 3
     @test size(dt8, 2) == 5
     @test sum(dt8[:d1_length]) == N
     @test all(dt8[:d1_length] .> 0)
     @test dt8[:d1_length] == [4, 5, 11]
-    @test isequal(dt8, aggregate(groupby(dt7, :d2, sort=true), [sum, length]))
-    @test isequal(dt8[1, :d1_length], 4)
-    @test isequal(dt8[2, :d1_length], 5)
-    @test isequal(dt8[3, :d1_length], 11)
-    @test isequal(dt8, aggregate(groupby(dt7, :d2), [sum, length], sort=true))
+    @test dt8 == aggregate(groupby(dt7, :d2, sort=true), [sum, length])
+    @test dt8[1, :d1_length] == 4
+    @test dt8[2, :d1_length] == 5
+    @test dt8[3, :d1_length] == 11
+    @test dt8 == aggregate(groupby(dt7, :d2), [sum, length], sort=true)
 
     dt9 = dt7 |> groupby([:d2], sort=true) |> [sum, length]
-    @test isequal(dt9, dt8)
+    @test dt9 == dt8
     dt9 = aggregate(dt7, :d2, [sum, length], sort=true)
-    @test isequal(dt9, dt8)
+    @test dt9 == dt8
 
     dt10 = DataTable(
         Any[[1:4;], [2:5;], ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],
@@ -141,22 +141,22 @@ module TestData
     @test ggd[2][1, :d4] == "d"
 
     #test_group("reshape")
-    d1 = DataTable(a = Vector(repeat([1:3;], inner = [4])),
-                   b = Vector(repeat([1:4;], inner = [3])),
-                   c = Vector(randn(12)),
-                   d = Vector(randn(12)),
-                   e = Vector(map(string, 'a':'l')))
+    d1 = DataTable(a = repeat([1:3;], inner = [4]),
+                   b = repeat([1:4;], inner = [3]),
+                   c = randn(12),
+                   d = randn(12),
+                   e = map(string, 'a':'l'))
 
     stack(d1, :a)
     d1s = stack(d1, [:a, :b])
     d1s2 = stack(d1, [:c, :d])
     d1s3 = stack(d1)
     d1m = melt(d1, [:c, :d, :e])
-    @test isequal(d1s[1:12, :c], d1[:c])
-    @test isequal(d1s[13:24, :c], d1[:c])
-    @test isequal(d1s2, d1s3)
+    @test d1s[1:12, :c] == d1[:c]
+    @test d1s[13:24, :c] == d1[:c]
+    @test d1s2 == d1s3
     @test names(d1s) == [:variable, :value, :c, :d, :e]
-    @test isequal(d1s, d1m)
+    @test d1s == d1m
     d1m = melt(d1[[1,3,4]], :a)
     @test names(d1m) == [:variable, :value, :a]
 
@@ -171,11 +171,11 @@ module TestData
     d1s2 = stackdt(d1, [:c, :d])
     d1s3 = stackdt(d1)
     d1m = meltdt(d1, [:c, :d, :e])
-    @test isequal(d1s[1:12, :c], d1[:c])
-    @test isequal(d1s[13:24, :c], d1[:c])
-    @test isequal(d1s2, d1s3)
+    @test d1s[1:12, :c] == d1[:c]
+    @test d1s[13:24, :c] == d1[:c]
+    @test d1s2 == d1s3
     @test names(d1s) == [:variable, :value, :c, :d, :e]
-    @test isequal(d1s, d1m)
+    @test d1s == d1m
     d1m = meltdt(d1[[1,3,4]], :a)
     @test names(d1m) == [:variable, :value, :a]
 
@@ -184,80 +184,79 @@ module TestData
     d1m_named = meltdt(d1, [:c, :d, :e], variable_name=:letter, value_name=:someval)
     @test names(d1m_named) == [:letter, :someval, :c, :d, :e]
 
-    d1s[:id] = Vector([1:12; 1:12])
-    d1s2[:id] =  Vector([1:12; 1:12])
+    d1s[:id] = [1:12; 1:12]
+    d1s2[:id] =  [1:12; 1:12]
     d1us = unstack(d1s, :id, :variable, :value)
     d1us2 = unstack(d1s2)
     d1us3 = unstack(d1s2, :variable, :value)
-    @test isequal(d1us[:a], d1[:a])
-    @test isequal(d1us2[:d], d1[:d])
-    @test isequal(d1us2[:3], d1[:d])
+    @test d1us[:a] == d1[:a]
+    @test d1us2[:d] == d1[:d]
+    @test d1us2[:3] == d1[:d]
 
     #test_group("merge")
 
     srand(1)
-    dt1 = DataTable(a = shuffle!(Vector(1:10)),
-                    b = Vector(rand([:A,:B], 10)),
-                    v1 = Vector(randn(10)))
+    dt1 = DataTable(a = shuffle!(collect(1:10)),
+                    b = rand([:A,:B], 10),
+                    v1 = randn(10))
 
-    dt2 = DataTable(a = shuffle!(Vector(1:5)),
-                    b2 = Vector(rand([:A,:B,:C], 5)),
-                    v2 = Vector(randn(5)))
+    dt2 = DataTable(a = shuffle!(collect(1:5)),
+                    b2 = rand([:A,:B,:C], 5),
+                    v2 = randn(5))
 
     m1 = join(dt1, dt2, on = :a, kind=:inner)
-    @test isequal(m1[:a], dt1[:a][dt1[:a] .<= 5]) # preserves dt1 order
+    @test m1[:a] == dt1[:a][dt1[:a] .<= 5] # preserves dt1 order
     m2 = join(dt1, dt2, on = :a, kind = :outer)
-    @test isequal(m2[:a], dt1[:a]) # preserves dt1 order
-    @test isequal(m2[:b], dt1[:b]) # preserves dt1 order
+    @test m2[:a] == dt1[:a] # preserves dt1 order
+    @test m2[:b] == dt1[:b] # preserves dt1 order
     m2 = join(dt1, dt2, on = :a, kind = :outer)
-    @test isequal(m2[:b2],
-                  ?(Symbol)[null, :A, :A, null, :C, null, null, :B, null, :A])
+    @test m2[:b2] == [null, :A, :A, null, :C, null, null, :B, null, :A]
 
-    dt1 = DataTable(a = Vector([1, 2, 3]),
-                    b = Vector(["America", "Europe", "Africa"]))
-    dt2 = DataTable(a = Vector([1, 2, 4]),
-                    c = Vector(["New World", "Old World", "New World"]))
+    dt1 = DataTable(a = [1, 2, 3],
+                    b = ["America", "Europe", "Africa"])
+    dt2 = DataTable(a = [1, 2, 4],
+                    c = ["New World", "Old World", "New World"])
 
     m1 = join(dt1, dt2, on = :a, kind = :inner)
-    @test isequal(m1[:a], Vector([1, 2]))
+    @test m1[:a] == [1, 2]
 
     m2 = join(dt1, dt2, on = :a, kind = :left)
-    @test isequal(m2[:a], Vector([1, 2, 3]))
+    @test m2[:a] == [1, 2, 3]
 
     m3 = join(dt1, dt2, on = :a, kind = :right)
-    @test isequal(m3[:a], Vector([1, 2, 4]))
+    @test m3[:a] == [1, 2, 4]
 
     m4 = join(dt1, dt2, on = :a, kind = :outer)
-    @test isequal(m4[:a], Vector([1, 2, 3, 4]))
+    @test m4[:a] == [1, 2, 3, 4]
 
     # test with nulls (issue #185)
     dt1 = DataTable()
-    dt1[:A] = Vector(["a", "b", "a", null])
-    dt1[:B] = Vector([1, 2, 1, 3])
+    dt1[:A] = ["a", "b", "a", null]
+    dt1[:B] = [1, 2, 1, 3]
 
     dt2 = DataTable()
-    dt2[:A] = Vector(["a", null, "c"])
-    dt2[:C] = Vector([1, 2, 4])
+    dt2[:A] = ["a", null, "c"]
+    dt2[:C] = [1, 2, 4]
 
     m1 = join(dt1, dt2, on = :A)
     @test size(m1) == (3,3)
-    @test isequal(m1[:A], Vector(["a","a", null]))
+    @test m1[:A] == ["a","a", null]
 
     m2 = join(dt1, dt2, on = :A, kind = :outer)
     @test size(m2) == (5,3)
-    @test isequal(m2[:A], Vector(["a", "b", "a", null, "c"]))
+    @test m2[:A] == ["a", "b", "a", null, "c"]
 
     srand(1)
     dt1 = DataTable(
-        a = Vector(rand([:x,:y], 10)),
-        b = Vector(rand([:A,:B], 10)),
-        v1 = Vector(randn(10))
+        a = rand([:x,:y], 10),
+        b = rand([:A,:B], 10),
+        v1 = randn(10)
     )
 
     dt2 = DataTable(
         a = Vector{?Symbol}([:x,:y][[1,2,1,1,2]]),
-        b = Vector([:A,:B,:C][[1,1,1,2,3]]),
-        v2 = Vector(randn(5))
+        b = [:A,:B,:C][[1,1,1,2,3]],
+        v2 = randn(5)
     )
     dt2[1,:a] = null
 
@@ -291,12 +290,12 @@ module TestData
 
     m1 = join(dt1, dt2, on = :a)
     m2 = join(dt1, dt2, on = [:x1, :x2, :x3])
-    @test isequal(sort(m1[:a]), sort(m2[:a]))
+    @test sort(m1[:a]) == sort(m2[:a])
 
     # test nonunique() with extra argument
-    dt1 = DataTable(a = Vector(["a", "b", "a", "b", "a", "b"]),
-                    b = Vector(1:6),
-                    c = Vector([1:3;1:3]))
+    dt1 = DataTable(a = ["a", "b", "a", "b", "a", "b"],
+                    b = 1:6,
+                    c = [1:3;1:3])
     dt = vcat(dt1, dt1)
     @test find(nonunique(dt)) == collect(7:12)
     @test find(nonunique(dt, :)) == collect(7:12)
@@ -318,5 +317,5 @@ module TestData
 
     #test unique!() with extra argument
     unique!(dt, [1, 3])
-    @test isequal(dt, dt1)
+    @test dt == dt1
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,5 +1,5 @@
 module TestData
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
     importall Base # so that we get warnings for conflicts
 
     #test_group("Vector creation")
@@ -82,7 +82,7 @@ module TestData
     N = 20
     #Cast to Int64 as rand() behavior differs between Int32/64
     d1 = rand(map(Int64, 1:2), N)
-    d2 = NullableCategoricalArray(["A", "B", null])[rand(map(Int64, 1:3), N)]
+    d2 = CategoricalArray(["A", "B", null])[rand(map(Int64, 1:3), N)]
     d3 = randn(N)
     d4 = randn(N)
     dt7 = DataTable(Any[d1, d2, d3], [:d1, :d2, :d3])
@@ -109,7 +109,7 @@ module TestData
     @test dt8[1, :d1_sum] == sum(dt7[:d1])
 
     dt8 = aggregate(dt7, :d2, [sum, length], sort=true)
-    @test dt8[1:2, :d2] == NullableCategoricalArray(["A", "B"])
+    @test dt8[1:2, :d2] == CategoricalArray{Union{String, Null}}(["A", "B"])
     @test size(dt8, 1) == 3
     @test size(dt8, 2) == 5
     @test sum(dt8[:d1_length]) == N
@@ -254,7 +254,7 @@ module TestData
     )
 
     dt2 = DataTable(
-        a = Vector{?Symbol}([:x,:y][[1,2,1,1,2]]),
+        a = Vector{Union{Symbol, Null}}([:x,:y][[1,2,1,1,2]]),
         b = [:A,:B,:C][[1,1,1,2,3]],
         v2 = randn(5)
     )
@@ -266,9 +266,9 @@ module TestData
     # m2 = join(dt1, dt2, on = ["a","b"], kind = :outer)
     # @test m2[10,:v2] == null
     # @test m2[:a] ==
-    #               (?String)["x", "x", "y", "y",
-    #                         "x", "x", "x", "x", "x", "y",
-    #                         null, "y"]
+    #               Union{String, Null}["x", "x", "y", "y",
+    #                                   "x", "x", "x", "x", "x", "y",
+    #                                   null, "y"]
 
     srand(1)
     function spltdt(d)

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,23 +1,22 @@
 module TestData
     importall Base # so that we get warnings for conflicts
     using Base.Test
-    using DataTables
-    using Compat
+    using DataTables, Nulls
 
-    #test_group("NullableArray creation")
-    nvint = NullableArray(Nullable{Int}[1, 2, Nullable(), 4])
-    nvint2 = NullableArray(5:8)
-    nvint3 = NullableArray(5:8)
-    nvflt = NullableArray(Nullable{Float64}[1.0, 2.0, Nullable(), 4.0])
-    nvstr = NullableArray(Nullable{Compat.ASCIIString}["one", "two", Nullable(), "four"])
-    dvdict = NullableArray(Dict, 4)    # for issue #199
+    #test_group("Vector creation")
+    nvint = ?(Int)[1, 2, null, 4]
+    nvint2 = Vector(5:8)
+    nvint3 = Vector(5:8)
+    nvflt = ?(Float64)[1.0, 2.0, null, 4.0]
+    nvstr = ?(String)["one", "two", null, "four"]
+    dvdict = Vector{Dict}(4)    # for issue #199
 
     #test_group("constructors")
     dt1 = DataTable(Any[nvint, nvstr], [:Ints, :Strs])
     dt2 = DataTable(Any[nvint, nvstr])
     dt3 = DataTable(Any[nvint])
-    dt4 = DataTable(Any[NullableArray(1:4), NullableArray(1:4)])
-    dt5 = DataTable(Any[NullableArray([1,2,3,4]), nvstr])
+    dt4 = DataTable(Any[Vector(1:4), Vector(1:4)])
+    dt5 = DataTable(Any[Vector([1,2,3,4]), nvstr])
     dt6 = DataTable(Any[nvint, nvint, nvstr], [:A, :B, :C])
     dt7 = DataTable(x = nvint, y = nvstr)
     @test size(dt7) == (4, 2)
@@ -31,9 +30,9 @@ module TestData
     @test names(dt7) == [:x, :y]
 
     #test_group("ref")
-    @test isequal(dt6[2, 3], Nullable("two"))
+    @test isequal(dt6[2, 3], "two")
     @test isnull(dt6[3, 3])
-    @test isequal(dt6[2, :C], Nullable("two"))
+    @test isequal(dt6[2, :C], "two")
     @test isequal(dt6[:B], nvint)
     @test size(dt6[[2,3]], 2) == 2
     @test size(dt6[2,:], 1) == 1
@@ -43,12 +42,12 @@ module TestData
     # lots more to do
 
     #test_group("assign")
-    dt6[3] = NullableArray(["un", "deux", "troix", "quatre"])
-    @test isequal(dt6[1, 3], Nullable("un"))
-    dt6[:B] = NullableArray([4, 3, 2, 1])
-    @test isequal(dt6[1,2], Nullable(4))
-    dt6[:D] = NullableArray([true, false, true, false])
-    @test isequal(dt6[1,4], Nullable(true))
+    dt6[3] = Vector(["un", "deux", "troix", "quatre"])
+    @test isequal(dt6[1, 3], "un")
+    dt6[:B] = Vector([4, 3, 2, 1])
+    @test isequal(dt6[1,2], 4)
+    dt6[:D] = Vector([true, false, true, false])
+    @test isequal(dt6[1,4], true)
     delete!(dt6, :D)
     @test names(dt6) == [:A, :B, :C]
     @test size(dt6, 2) == 3
@@ -74,7 +73,7 @@ module TestData
     @test size(sdt6d) == (2,1)
 
     #test_group("ref")
-    @test isequal(sdt6a[1,2], Nullable(4))
+    @test isequal(sdt6a[1,2], 4)
 
     #test_context("Within")
     #test_group("Associative")
@@ -83,23 +82,23 @@ module TestData
     srand(1)
     N = 20
     #Cast to Int64 as rand() behavior differs between Int32/64
-    d1 = NullableArray(rand(map(Int64, 1:2), N))
-    d2 = NullableCategoricalArray(Nullable{String}["A", "B", Nullable()])[rand(map(Int64, 1:3), N)]
-    d3 = NullableArray(randn(N))
-    d4 = NullableArray(randn(N))
+    d1 = Vector(rand(map(Int64, 1:2), N))
+    d2 = NullableCategoricalArray(?(String)["A", "B", null])[rand(map(Int64, 1:3), N)]
+    d3 = Vector(randn(N))
+    d4 = Vector(randn(N))
     dt7 = DataTable(Any[d1, d2, d3], [:d1, :d2, :d3])
 
     #test_group("groupby")
     gd = groupby(dt7, :d1)
     @test length(gd) == 2
-    # @test isequal(gd[2]["d2"], CategoricalVector["A", "B", Nullable(), "A", Nullable(), Nullable(), Nullable(), Nullable()])
+    # @test isequal(gd[2]["d2"], CategoricalVector["A", "B", null, "A", null, null, null, null])
     @test isequal(sum(gd[2][:d3]), sum(dt7[:d3][Vector(dt7[:d1]) .== 2]))
 
     g1 = groupby(dt7, [:d1, :d2])
     g2 = groupby(dt7, [:d2, :d1])
     @test isequal(sum(g1[1][:d3]), sum(g2[1][:d3]))
 
-    res = Nullable(0.0)
+    res = 0.0
     for x in g1
         res += sum(x[:d1])
     end
@@ -143,11 +142,11 @@ module TestData
     @test ggd[2][1, :d4] == "d"
 
     #test_group("reshape")
-    d1 = DataTable(a = NullableArray(repeat([1:3;], inner = [4])),
-                   b = NullableArray(repeat([1:4;], inner = [3])),
-                   c = NullableArray(randn(12)),
-                   d = NullableArray(randn(12)),
-                   e = NullableArray(map(string, 'a':'l')))
+    d1 = DataTable(a = Vector(repeat([1:3;], inner = [4])),
+                   b = Vector(repeat([1:4;], inner = [3])),
+                   c = Vector(randn(12)),
+                   d = Vector(randn(12)),
+                   e = Vector(map(string, 'a':'l')))
 
     stack(d1, :a)
     d1s = stack(d1, [:a, :b])
@@ -186,8 +185,8 @@ module TestData
     d1m_named = meltdt(d1, [:c, :d, :e], variable_name=:letter, value_name=:someval)
     @test names(d1m_named) == [:letter, :someval, :c, :d, :e]
 
-    d1s[:id] = NullableArray([1:12; 1:12])
-    d1s2[:id] =  NullableArray([1:12; 1:12])
+    d1s[:id] = Vector([1:12; 1:12])
+    d1s2[:id] =  Vector([1:12; 1:12])
     d1us = unstack(d1s, :id, :variable, :value)
     d1us2 = unstack(d1s2)
     d1us3 = unstack(d1s2, :variable, :value)
@@ -195,98 +194,83 @@ module TestData
     @test isequal(d1us2[:d], d1[:d])
     @test isequal(d1us2[:3], d1[:d])
 
-
-
-    d2 = DataTable(id1 = [:a, :a, :a, :b],
-                   id2 = [:A, :B, :B, :B],
-                   id3 = [:t, :f, :t, :f],
-                   val = [.1, .2, .3, .4])
-
-
     #test_group("merge")
 
     srand(1)
-    dt1 = DataTable(a = shuffle!(NullableArray(1:10)),
-                    b = NullableArray(rand([:A,:B], 10)),
-                    v1 = NullableArray(randn(10)))
+    dt1 = DataTable(a = shuffle!(Vector(1:10)),
+                    b = Vector(rand([:A,:B], 10)),
+                    v1 = Vector(randn(10)))
 
-    dt2 = DataTable(a = shuffle!(NullableArray(1:5)),
-                    b2 = NullableArray(rand([:A,:B,:C], 5)),
-                    v2 = NullableArray(randn(5)))
+    dt2 = DataTable(a = shuffle!(Vector(1:5)),
+                    b2 = Vector(rand([:A,:B,:C], 5)),
+                    v2 = Vector(randn(5)))
 
     m1 = join(dt1, dt2, on = :a, kind=:inner)
-    @test isequal(m1[:a], dt1[:a][dt1[:a].values .<= 5]) # preserves dt1 order
+    @test isequal(m1[:a], dt1[:a][dt1[:a] .<= 5]) # preserves dt1 order
     m2 = join(dt1, dt2, on = :a, kind = :outer)
     @test isequal(m2[:a], dt1[:a]) # preserves dt1 order
     @test isequal(m2[:b], dt1[:b]) # preserves dt1 order
-    # TODO: Re-enable
     m2 = join(dt1, dt2, on = :a, kind = :outer)
-    # @test isequal(m2[:b2],
-    #               NullableArray(Nullable{String}["A", "B", "B", "B", "B",
-    #                                              Nullable(), Nullable(),
-    #                                              Nullable(), Nullable(), Nullable()]))
-    # @test isequal(m2[:b2],
-    #               NullableArray(Nullable{String}["B", "B", "B", "C", "B",
-    #                                              Nullable(), Nullable(),
-    #                                              Nullable(), Nullable(), Nullable()]))
+    @test isequal(m2[:b2],
+                  ?(Symbol)[null, :A, :A, null, :C, null, null, :B, null, :A])
 
-    dt1 = DataTable(a = NullableArray([1, 2, 3]),
-                    b = NullableArray(["America", "Europe", "Africa"]))
-    dt2 = DataTable(a = NullableArray([1, 2, 4]),
-                    c = NullableArray(["New World", "Old World", "New World"]))
+    dt1 = DataTable(a = Vector([1, 2, 3]),
+                    b = Vector(["America", "Europe", "Africa"]))
+    dt2 = DataTable(a = Vector([1, 2, 4]),
+                    c = Vector(["New World", "Old World", "New World"]))
 
     m1 = join(dt1, dt2, on = :a, kind = :inner)
-    @test isequal(m1[:a], NullableArray([1, 2]))
+    @test isequal(m1[:a], Vector([1, 2]))
 
     m2 = join(dt1, dt2, on = :a, kind = :left)
-    @test isequal(m2[:a], NullableArray([1, 2, 3]))
+    @test isequal(m2[:a], Vector([1, 2, 3]))
 
     m3 = join(dt1, dt2, on = :a, kind = :right)
-    @test isequal(m3[:a], NullableArray([1, 2, 4]))
+    @test isequal(m3[:a], Vector([1, 2, 4]))
 
     m4 = join(dt1, dt2, on = :a, kind = :outer)
-    @test isequal(m4[:a], NullableArray([1, 2, 3, 4]))
+    @test isequal(m4[:a], Vector([1, 2, 3, 4]))
 
     # test with nulls (issue #185)
     dt1 = DataTable()
-    dt1[:A] = NullableArray(["a", "b", "a", Nullable()])
-    dt1[:B] = NullableArray([1, 2, 1, 3])
+    dt1[:A] = Vector(["a", "b", "a", null])
+    dt1[:B] = Vector([1, 2, 1, 3])
 
     dt2 = DataTable()
-    dt2[:A] = NullableArray(["a", Nullable(), "c"])
-    dt2[:C] = NullableArray([1, 2, 4])
+    dt2[:A] = Vector(["a", null, "c"])
+    dt2[:C] = Vector([1, 2, 4])
 
     m1 = join(dt1, dt2, on = :A)
     @test size(m1) == (3,3)
-    @test isequal(m1[:A], NullableArray(["a","a", Nullable()]))
+    @test isequal(m1[:A], Vector(["a","a", null]))
 
     m2 = join(dt1, dt2, on = :A, kind = :outer)
     @test size(m2) == (5,3)
-    @test isequal(m2[:A], NullableArray(["a", "b", "a", Nullable(), "c"]))
+    @test isequal(m2[:A], Vector(["a", "b", "a", null, "c"]))
 
     srand(1)
     dt1 = DataTable(
-        a = NullableArray(rand([:x,:y], 10)),
-        b = NullableArray(rand([:A,:B], 10)),
-        v1 = NullableArray(randn(10))
+        a = Vector(rand([:x,:y], 10)),
+        b = Vector(rand([:A,:B], 10)),
+        v1 = Vector(randn(10))
     )
 
     dt2 = DataTable(
-        a = NullableArray([:x,:y][[1,2,1,1,2]]),
-        b = NullableArray([:A,:B,:C][[1,1,1,2,3]]),
-        v2 = NullableArray(randn(5))
+        a = Vector{?Symbol}([:x,:y][[1,2,1,1,2]]),
+        b = Vector([:A,:B,:C][[1,1,1,2,3]]),
+        v2 = Vector(randn(5))
     )
-    dt2[1,:a] = Nullable()
+    dt2[1,:a] = null
 
     # # TODO: Restore this functionality
     # m1 = join(dt1, dt2, on = [:a,:b])
-    # @test isequal(m1[:a], NullableArray(["x", "x", "y", "y", fill("x", 5)]))
+    # @test isequal(m1[:a], Vector(["x", "x", "y", "y", fill("x", 5)]))
     # m2 = join(dt1, dt2, on = ["a","b"], kind = :outer)
-    # @test isequal(m2[10,:v2], Nullable())
+    # @test isequal(m2[10,:v2], null)
     # @test isequal(m2[:a],
-    #               NullableArray(Nullable{String}["x", "x", "y", "y",
+    #               Vector(?(String)["x", "x", "y", "y",
     #                                              "x", "x", "x", "x", "x", "y",
-    #                                              Nullable(), "y"])
+    #                                              null, "y"])
 
     srand(1)
     function spltdt(d)
@@ -306,14 +290,14 @@ module TestData
     )
     dt2 = spltdt(dt2)
 
-    # m1 = join(dt1, dt2, on = :a)
-    # m2 = join(dt1, dt2, on = [:x1, :x2, :x3])
-    # @test isequal(sort(m1[:a]), sort(m2[:a]))
+    m1 = join(dt1, dt2, on = :a)
+    m2 = join(dt1, dt2, on = [:x1, :x2, :x3])
+    @test isequal(sort(m1[:a]), sort(m2[:a]))
 
     # test nonunique() with extra argument
-    dt1 = DataTable(a = NullableArray(["a", "b", "a", "b", "a", "b"]),
-                    b = NullableArray(1:6),
-                    c = NullableArray([1:3;1:3]))
+    dt1 = DataTable(a = Vector(["a", "b", "a", "b", "a", "b"]),
+                    b = Vector(1:6),
+                    c = Vector([1:3;1:3]))
     dt = vcat(dt1, dt1)
     @test find(nonunique(dt)) == collect(7:12)
     @test find(nonunique(dt, :)) == collect(7:12)

--- a/test/data.jl
+++ b/test/data.jl
@@ -41,7 +41,7 @@ module TestData
     # lots more to do
 
     #test_group("assign")
-    dt6[3] = Vector(["un", "deux", "troix", "quatre"])
+    dt6[3] = Vector(["un", "deux", "trois", "quatre"])
     @test isequal(dt6[1, 3], "un")
     dt6[:B] = Vector([4, 3, 2, 1])
     @test isequal(dt6[1,2], 4)
@@ -268,8 +268,8 @@ module TestData
     # @test isequal(m2[10,:v2], null)
     # @test isequal(m2[:a],
     #               Vector(?(String)["x", "x", "y", "y",
-    #                                              "x", "x", "x", "x", "x", "y",
-    #                                              null, "y"])
+    #                                "x", "x", "x", "x", "x", "y",
+    #                                null, "y"])
 
     srand(1)
     function spltdt(d)

--- a/test/data.jl
+++ b/test/data.jl
@@ -82,7 +82,7 @@ module TestData
     N = 20
     #Cast to Int64 as rand() behavior differs between Int32/64
     d1 = rand(map(Int64, 1:2), N)
-    d2 = NullableCategoricalArray(?(String)["A", "B", null])[rand(map(Int64, 1:3), N)]
+    d2 = NullableCategoricalArray(["A", "B", null])[rand(map(Int64, 1:3), N)]
     d3 = randn(N)
     d4 = randn(N)
     dt7 = DataTable(Any[d1, d2, d3], [:d1, :d2, :d3])
@@ -90,7 +90,7 @@ module TestData
     #test_group("groupby")
     gd = groupby(dt7, :d1)
     @test length(gd) == 2
-    # @test isequal(gd[2]["d2"], CategoricalVector["A", "B", null, "A", null, null, null, null])
+    # @test gd[2]["d2"] == CategoricalVector["A", "B", null, "A", null, null, null, null]
     @test sum(gd[2][:d3]) == sum(dt7[:d3][dt7[:d1] .== 2])
 
     g1 = groupby(dt7, [:d1, :d2])
@@ -262,13 +262,13 @@ module TestData
 
     # # TODO: Restore this functionality
     # m1 = join(dt1, dt2, on = [:a,:b])
-    # @test isequal(m1[:a], Vector(["x", "x", "y", "y", fill("x", 5)]))
+    # @test m1[:a] == Vector(["x", "x", "y", "y", fill("x", 5)]))
     # m2 = join(dt1, dt2, on = ["a","b"], kind = :outer)
-    # @test isequal(m2[10,:v2], null)
-    # @test isequal(m2[:a],
-    #               Vector(?(String)["x", "x", "y", "y",
-    #                                "x", "x", "x", "x", "x", "y",
-    #                                null, "y"])
+    # @test m2[10,:v2] == null
+    # @test m2[:a] ==
+    #               (?String)["x", "x", "y", "y",
+    #                         "x", "x", "x", "x", "x", "y",
+    #                         null, "y"]
 
     srand(1)
     function spltdt(d)
@@ -306,14 +306,14 @@ module TestData
     @test find(nonunique(dt, 1)) == collect(3:12)
 
     # Test unique() with extra argument
-    @test isequal(unique(dt), dt1)
-    @test isequal(unique(dt, :), dt1)
-    @test isequal(unique(dt, Colon()), dt1)
-    @test isequal(unique(dt, 2:3), dt1)
-    @test isequal(unique(dt, 3), dt1[1:3,:])
-    @test isequal(unique(dt, [1, 3]), dt1)
-    @test isequal(unique(dt, [:a, :c]), dt1)
-    @test isequal(unique(dt, :a), dt1[1:2,:])
+    @test unique(dt) == dt1
+    @test unique(dt, :) == dt1
+    @test unique(dt, Colon()) == dt1
+    @test unique(dt, 2:3) == dt1
+    @test unique(dt, 3) == dt1[1:3,:]
+    @test unique(dt, [1, 3]) == dt1
+    @test unique(dt, [:a, :c]) == dt1
+    @test unique(dt, :a) == dt1[1:2,:]
 
     #test unique!() with extra argument
     unique!(dt, [1, 3])

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -5,14 +5,14 @@ module TestDataTable
     # Equality
     #
 
-    @test isequal(DataTable(a=[1, 2, 3], b=[4, 5, 6]), DataTable(a=[1, 2, 3], b=[4, 5, 6]))
-    @test !isequal(DataTable(a=[1, 2], b=[4, 5]), DataTable(a=[1, 2, 3], b=[4, 5, 6]))
-    @test !isequal(DataTable(a=[1, 2, 3], b=[4, 5, 6]), DataTable(a=[1, 2, 3]))
-    @test !isequal(DataTable(a=[1, 2, 3], b=[4, 5, 6]), DataTable(a=[1, 2, 3], c=[4, 5, 6]))
-    @test !isequal(DataTable(a=[1, 2, 3], b=[4, 5, 6]), DataTable(b=[4, 5, 6], a=[1, 2, 3]))
-    @test !isequal(DataTable(a=[1, 2, 2], b=[4, 5, 6]), DataTable(a=[1, 2, 3], b=[4, 5, 6]))
-    @test isequal(DataTable(a=[1, 2, null], b=[4, 5, 6]),
-                  DataTable(a=[1, 2, null], b=[4, 5, 6]))
+    @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) == DataTable(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataTable(a=[1, 2], b=[4, 5]) != DataTable(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(a=[1, 2, 3])
+    @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(a=[1, 2, 3], c=[4, 5, 6])
+    @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(b=[4, 5, 6], a=[1, 2, 3])
+    @test DataTable(a=[1, 2, 2], b=[4, 5, 6]) != DataTable(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataTable(a=[1, 2, null], b=[4, 5, 6]) ==
+                  DataTable(a=[1, 2, null], b=[4, 5, 6])
 
     @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) == DataTable(a=[1, 2, 3], b=[4, 5, 6])
     @test DataTable(a=[1, 2], b=[4, 5]) != DataTable(a=[1, 2, 3], b=[4, 5, 6])
@@ -67,23 +67,23 @@ module TestDataTable
 
     # Insert single value
     x[:d] = 3
-    @test isequal(x[:d], [3, 3, 3])
+    @test x[:d] == [3, 3, 3]
 
     x0[:d] = 3
     @test x0[:d] == Int[]
 
     # similar / nulls
-    dt = DataTable(a = ?[1],
-                   b = ?["b"],
+    dt = DataTable(a = (?Int)[1],
+                   b = (?String)["b"],
                    c = NullableCategoricalArray([3.3]))
     nulldt = DataTable(a = nulls(Int, 2),
                        b = nulls(String, 2),
                        c = NullableCategoricalArray{Float64}(2))
-    @test isequal(nulldt, similar(dt, 2))
+    @test nulldt == similar(dt, 2)
 
     # Associative methods
 
-    dt = DataTable(a=[1, 2], b=[3., 4.])
+    dt = DataTable(a=[1, 2], b=[3.0, 4.0])
     @test haskey(dt, :a)
     @test !haskey(dt, :c)
     @test get(dt, :a, -1) === dt.columns[1]
@@ -94,19 +94,19 @@ module TestDataTable
     @test isempty(dt.columns)
     @test isempty(dt)
 
-    dt = DataTable(a=(?Int)[1, 2], b=(?Float64)[3., 4.])
+    dt = DataTable(a=(?Int)[1, 2], b=(?Float64)[3.0, 4.0])
     @test_throws BoundsError insert!(dt, 5, ["a", "b"], :newcol)
     @test_throws ErrorException insert!(dt, 1, ["a"], :newcol)
-    @test isequal(insert!(dt, 1, ["a", "b"], :newcol), dt)
+    @test insert!(dt, 1, ["a", "b"], :newcol) == dt
     @test names(dt) == [:newcol, :a, :b]
-    @test isequal(dt[:a], (?Int)[1, 2])
-    @test isequal(dt[:b], (?Float64)[3., 4.])
-    @test isequal(dt[:newcol], ["a", "b"])
+    @test dt[:a] == [1, 2]
+    @test dt[:b] == [3.0, 4.0]
+    @test dt[:newcol] == ["a", "b"]
 
-    dt = DataTable(a=[1, 2], b=[3., 4.])
+    dt = DataTable(a=[1, 2], b=[3.0, 4.0])
     dt2 = DataTable(b=["a", "b"], c=[:c, :d])
-    @test isequal(merge!(dt, dt2), dt)
-    @test isequal(dt, DataTable(a=[1, 2], b=["a", "b"], c=[:c, :d]))
+    @test merge!(dt, dt2) == dt
+    @test dt == DataTable(a=[1, 2], b=["a", "b"], c=[:c, :d])
 
     #test_group("Empty DataTable constructors")
     dt = DataTable(?Int, 10, 3)
@@ -191,11 +191,11 @@ module TestDataTable
 
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
     push!(dtb, Any[3,"pear"])
-    @test isequal(dt, dtb)
+    @test dt == dtb
 
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
     push!(dtb, (3,"pear"))
-    @test isequal(dt, dtb)
+    @test dt == dtb
 
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
     @test_throws ArgumentError push!(dtb, (33.33,"pear"))
@@ -205,22 +205,22 @@ module TestDataTable
 
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
     push!(dtb, Dict(:first=>3, :second=>"pear"))
-    @test isequal(dt, dtb)
+    @test dt == dtb
 
     dt=DataTable( first=[1,2,3], second=["apple","orange","banana"] )
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
     push!(dtb, Dict("first"=>3, "second"=>"banana"))
-    @test isequal(dt, dtb)
+    @test dt == dtb
 
     dt0= DataTable( first=[1,2], second=["apple","orange"] )
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
     @test_throws ArgumentError push!(dtb, Dict(:first=>true, :second=>false))
-    @test isequal(dt0, dtb)
+    @test dt0 == dtb
 
     dt0= DataTable( first=[1,2], second=["apple","orange"] )
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
     @test_throws ArgumentError push!(dtb, Dict("first"=>"chicken", "second"=>"stuff"))
-    @test isequal(dt0, dtb)
+    @test dt0 == dtb
 
     # delete!
     dt = DataTable(a=1, b=2, c=3, d=4, e=5)
@@ -232,46 +232,46 @@ module TestDataTable
     delete!(d, [:a, :e, :c])
     @test names(d) == [:b, :d]
     delete!(d, :b)
-    @test isequal(d, DataTable(d=4))
+    @test d == DataTable(d=4)
 
     d = copy(dt)
     delete!(d, [2, 5, 3])
     @test names(d) == [:a, :d]
     delete!(d, 2)
-    @test isequal(d, DataTable(a=1))
+    @test d == DataTable(a=1)
 
     # deleterows!
-    dt = DataTable(a=[1, 2], b=[3., 4.])
+    dt = DataTable(a=[1, 2], b=[3.0, 4.0])
     @test deleterows!(dt, 1) === dt
-    @test isequal(dt, DataTable(a=[2], b=[4.]))
+    @test dt == DataTable(a=[2], b=[4.0])
 
-    dt = DataTable(a=[1, 2], b=[3., 4.])
+    dt = DataTable(a=[1, 2], b=[3.0, 4.0])
     @test deleterows!(dt, 2) === dt
-    @test isequal(dt, DataTable(a=[1], b=[3.]))
+    @test dt == DataTable(a=[1], b=[3.0])
 
-    dt = DataTable(a=[1, 2, 3], b=[3., 4., 5.])
+    dt = DataTable(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
     @test deleterows!(dt, 2:3) === dt
-    @test isequal(dt, DataTable(a=[1], b=[3.]))
+    @test dt == DataTable(a=[1], b=[3.0])
 
-    dt = DataTable(a=[1, 2, 3], b=[3., 4., 5.])
+    dt = DataTable(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
     @test deleterows!(dt, [2, 3]) === dt
-    @test isequal(dt, DataTable(a=[1], b=[3.]))
+    @test dt == DataTable(a=[1], b=[3.0])
 
-    dt = DataTable(a=[1, 2], b=[3., 4.])
+    dt = DataTable(a=[1, 2], b=[3.0, 4.0])
     @test deleterows!(dt, 1) === dt
-    @test isequal(dt, DataTable(a=[2], b=[4.]))
+    @test dt == DataTable(a=[2], b=[4.0])
 
-    dt = DataTable(a=[1, 2], b=[3., 4.])
+    dt = DataTable(a=[1, 2], b=[3.0, 4.0])
     @test deleterows!(dt, 2) === dt
-    @test isequal(dt, DataTable(a=[1], b=[3.]))
+    @test dt == DataTable(a=[1], b=[3.0])
 
-    dt = DataTable(a=[1, 2, 3], b=[3., 4., 5.])
+    dt = DataTable(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
     @test deleterows!(dt, 2:3) === dt
-    @test isequal(dt, DataTable(a=[1], b=[3.]))
+    @test dt == DataTable(a=[1], b=[3.0])
 
-    dt = DataTable(a=[1, 2, 3], b=[3., 4., 5.])
+    dt = DataTable(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
     @test deleterows!(dt, [2, 3]) === dt
-    @test isequal(dt, DataTable(a=[1], b=[3.]))
+    @test dt == DataTable(a=[1], b=[3.0])
 
     # describe
     #suppress output and test that describe() does not throw
@@ -280,16 +280,16 @@ module TestDataTable
         @test nothing == describe(f, DataTable(a=[1, 2], b=Any["3", null]))
         @test nothing ==
               describe(f, DataTable(a=[1, 2],
-                                    b=(?String)["3", null]))
+                                    b=["3", null]))
         @test nothing ==
               describe(f, DataTable(a=CategoricalArray([1, 2]),
-                                    b=NullableCategoricalArray((?String)["3", null])))
+                                    b=NullableCategoricalArray(["3", null])))
         @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, CategoricalArray([1, 2, 3]))
         @test nothing == describe(f, Any["1", "2", null])
-        @test nothing == describe(f, (?String)["1", "2", null])
-        @test nothing == describe(f, NullableCategoricalArray((?String)["1", "2", null]))
+        @test nothing == describe(f, ["1", "2", null])
+        @test nothing == describe(f, NullableCategoricalArray(["1", "2", null]))
     end
 
     #Check the output of unstack
@@ -301,13 +301,13 @@ module TestDataTable
     #Unstack specifying a row column
     dt2 = unstack(dt, :Fish, :Key, :Value)
     #Unstack without specifying a row column
-    #FIXME
+    #FIXME: categoricalarrays
     # dt3 = unstack(dt, :Key, :Value)
     #The expected output
     dt4 = DataTable(Fish = (?String)["XXX", "Bob", "Batman"],
                     Color = (?String)[null, "Red", "Grey"],
                     Mass = (?String)[null, "12 g", "18 g"])
-    @test isequal(dt2, dt4)
+    @test dt2 == dt4
     @test typeof(dt2[:Fish]) <: NullableCategoricalArray{String,1,UInt32}
     # first column stays as CategoricalArray in dt3
     # @test isequal(dt3[:, 2:3], dt4[2:3, 2:3])
@@ -316,7 +316,7 @@ module TestDataTable
     dt2 = unstack(dt, :Fish, :Key, :Value)
     #This changes the expected result
     dt4[2,:Mass] = null
-    @test isequal(dt2, dt4)
+    @test dt2 == dt4
 
     dt = DataTable(A = 1:10, B = 'A':'J')
     @test !(dt[:,:] === dt)

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -300,8 +300,7 @@ module TestDataTable
     #Unstack specifying a row column
     dt2 = unstack(dt, :Fish, :Key, :Value)
     #Unstack without specifying a row column
-    #FIXME: categoricalarrays
-    # dt3 = unstack(dt, :Key, :Value)
+    dt3 = unstack(dt, :Key, :Value)
     #The expected output
     dt4 = DataTable(Fish = Union{String, Null}["XXX", "Bob", "Batman"],
                     Color = Union{String, Null}[null, "Red", "Grey"],
@@ -309,7 +308,7 @@ module TestDataTable
     @test dt2 == dt4
     @test typeof(dt2[:Fish]) <: CategoricalVector{Union{String, Null}}
     # first column stays as CategoricalArray in dt3
-    # @test dt3[:, 2:3] == dt4[2:3, 2:3]
+    @test dt3[:, 2:3] == dt4[2:3, 2:3]
     #Make sure unstack works with NULLs at the start of the value column
     dt[1,:Value] = null
     dt2 = unstack(dt, :Fish, :Key, :Value)

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -1,5 +1,5 @@
 module TestDataTable
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     #
     # Equality
@@ -73,12 +73,12 @@ module TestDataTable
     @test x0[:d] == Int[]
 
     # similar / nulls
-    dt = DataTable(a = (?Int)[1],
-                   b = (?String)["b"],
-                   c = NullableCategoricalArray([3.3]))
+    dt = DataTable(a = Union{Int, Null}[1],
+                   b = Union{String, Null}["b"],
+                   c = CategoricalArray{Union{Float64, Null}}([3.3]))
     nulldt = DataTable(a = nulls(Int, 2),
                        b = nulls(String, 2),
-                       c = NullableCategoricalArray{Float64}(2))
+                       c = CategoricalArray{Union{Float64, Null}}(2))
     @test nulldt == similar(dt, 2)
 
     # Associative methods
@@ -94,7 +94,7 @@ module TestDataTable
     @test isempty(dt.columns)
     @test isempty(dt)
 
-    dt = DataTable(a=(?Int)[1, 2], b=(?Float64)[3.0, 4.0])
+    dt = DataTable(a=Union{Int, Null}[1, 2], b=Union{Float64, Null}[3.0, 4.0])
     @test_throws BoundsError insert!(dt, 5, ["a", "b"], :newcol)
     @test_throws ErrorException insert!(dt, 1, ["a"], :newcol)
     @test insert!(dt, 1, ["a", "b"], :newcol) == dt
@@ -109,46 +109,46 @@ module TestDataTable
     @test dt == DataTable(a=[1, 2], b=["a", "b"], c=[:c, :d])
 
     #test_group("Empty DataTable constructors")
-    dt = DataTable(?Int, 10, 3)
+    dt = DataTable(Union{Int, Null}, 10, 3)
     @test size(dt, 1) == 10
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == Vector{?Int}
-    @test typeof(dt[:, 2]) == Vector{?Int}
-    @test typeof(dt[:, 3]) == Vector{?Int}
+    @test typeof(dt[:, 1]) == Vector{Union{Int, Null}}
+    @test typeof(dt[:, 2]) == Vector{Union{Int, Null}}
+    @test typeof(dt[:, 3]) == Vector{Union{Int, Null}}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
-    dt = DataTable([?Int, ?Float64, ?String], 100)
+    dt = DataTable([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}], 100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == Vector{?Int}
-    @test typeof(dt[:, 2]) == Vector{?Float64}
-    @test typeof(dt[:, 3]) == Vector{?String}
+    @test typeof(dt[:, 1]) == Vector{Union{Int, Null}}
+    @test typeof(dt[:, 2]) == Vector{Union{Float64, Null}}
+    @test typeof(dt[:, 3]) == Vector{Union{String, Null}}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
-    dt = DataTable([?Int, ?Float64, ?String],
+    dt = DataTable([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}],
                    [:A, :B, :C], 100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == Vector{?Int}
-    @test typeof(dt[:, 2]) == Vector{?Float64}
-    @test typeof(dt[:, 3]) == Vector{?String}
+    @test typeof(dt[:, 1]) == Vector{Union{Int, Null}}
+    @test typeof(dt[:, 2]) == Vector{Union{Float64, Null}}
+    @test typeof(dt[:, 3]) == Vector{Union{String, Null}}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
 
     #FIXME: something in CategoricalArrays
-    # dt = DataTable([?Int, ?Float64, ?String],
+    # dt = DataTable([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}],
     #                [:A, :B, :C], [false, false, true],100)
     # @test size(dt, 1) == 100
     # @test size(dt, 2) == 3
-    # @test typeof(dt[:, 1]) == Vector{?Int}
-    # @test typeof(dt[:, 2]) == Vector{?Float64}
-    # @test typeof(dt[:, 3]) == NullableCategoricalVector{String,UInt32}
+    # @test typeof(dt[:, 1]) == Vector{Union{Int, Null}}
+    # @test typeof(dt[:, 2]) == Vector{Union{Float64, Null}}
+    # @test typeof(dt[:, 3]) <: CategoricalVector{Union{String, Null}}
     # @test all(isnull, dt[:, 1])
     # @test all(isnull, dt[:, 2])
     # @test all(isnull, dt[:, 3])
@@ -283,19 +283,19 @@ module TestDataTable
                                     b=["3", null]))
         @test nothing ==
               describe(f, DataTable(a=CategoricalArray([1, 2]),
-                                    b=NullableCategoricalArray(["3", null])))
+                                    b=CategoricalArray(["3", null])))
         @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, CategoricalArray([1, 2, 3]))
         @test nothing == describe(f, Any["1", "2", null])
         @test nothing == describe(f, ["1", "2", null])
-        @test nothing == describe(f, NullableCategoricalArray(["1", "2", null]))
+        @test nothing == describe(f, CategoricalArray(["1", "2", null]))
     end
 
     #Check the output of unstack
-    dt = DataTable(Fish = NullableCategoricalArray(["Bob", "Bob", "Batman", "Batman"]),
-                   Key = (?String)["Mass", "Color", "Mass", "Color"],
-                   Value = (?String)["12 g", "Red", "18 g", "Grey"])
+    dt = DataTable(Fish = CategoricalArray{Union{String, Null}}(["Bob", "Bob", "Batman", "Batman"]),
+                   Key = Union{String, Null}["Mass", "Color", "Mass", "Color"],
+                   Value = Union{String, Null}["12 g", "Red", "18 g", "Grey"])
     # Check that reordering levels does not confuse unstack
     levels!(dt[1], ["XXX", "Bob", "Batman"])
     #Unstack specifying a row column
@@ -304,11 +304,11 @@ module TestDataTable
     #FIXME: categoricalarrays
     # dt3 = unstack(dt, :Key, :Value)
     #The expected output
-    dt4 = DataTable(Fish = (?String)["XXX", "Bob", "Batman"],
-                    Color = (?String)[null, "Red", "Grey"],
-                    Mass = (?String)[null, "12 g", "18 g"])
+    dt4 = DataTable(Fish = Union{String, Null}["XXX", "Bob", "Batman"],
+                    Color = Union{String, Null}[null, "Red", "Grey"],
+                    Mass = Union{String, Null}[null, "12 g", "18 g"])
     @test dt2 == dt4
-    @test typeof(dt2[:Fish]) <: NullableCategoricalArray{String,1,UInt32}
+    @test typeof(dt2[:Fish]) <: CategoricalVector{Union{String, Null}}
     # first column stays as CategoricalArray in dt3
     # @test dt3[:, 2:3] == dt4[2:3, 2:3]
     #Make sure unstack works with NULLs at the start of the value column
@@ -338,7 +338,7 @@ module TestDataTable
         @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
         @test udt == DataTable(Any[[1, 2], [1, 5], [2, 6],
                                    [3, 7], [4, 8]], [:id, :a, :b, :c, :d])
-        @test all(typeof.(udt.columns) .== Vector{?Int})
+        @test all(isa.(udt.columns, Vector{Union{Int, Null}}))
         dt = DataTable(Any[categorical(repeat(1:2, inner=4)),
                            categorical(repeat('a':'d', outer=2)), categorical(1:8)],
                        [:id, :variable, :value])
@@ -346,11 +346,11 @@ module TestDataTable
         # @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
         @test udt == DataTable(Any[[1, 2], [1, 5], [2, 6],
                                    [3, 7], [4, 8]], [:id, :a, :b, :c, :d])
-        @test all(typeof.(udt.columns) .== NullableCategoricalVector{Int, UInt32})
+        @test all(isa.(udt.columns, CategoricalVector{Union{Int, Null}}))
     end
 
     @testset "duplicate entries in unstack warnings" begin
-        dt = DataTable(id=(?Int)[1, 2, 1, 2], variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
+        dt = DataTable(id=Union{Int, Null}[1, 2, 1, 2], variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
         @static if VERSION >= v"0.6.0-dev.1980"
             @test_warn "Duplicate entries in unstack." unstack(dt, :id, :variable, :value)
             @test_warn "Duplicate entries in unstack at row 3." unstack(dt, :variable, :value)
@@ -407,11 +407,11 @@ module TestDataTable
 
     @testset "column conversions" begin
         dt = DataTable(Any[collect(1:10), collect(1:10)])
-        @test !isa(dt[1], Vector{?Int})
+        @test !isa(dt[1], Vector{Union{Int, Null}})
         nullable!(dt, 1)
-        @test isa(dt[1], Vector{?Int})
-        @test !isa(dt[2], Vector{?Int})
+        @test isa(dt[1], Vector{Union{Int, Null}})
+        @test !isa(dt[2], Vector{Union{Int, Null}})
         nullable!(dt, [1,2])
-        @test isa(dt[1], Vector{?Int}) && isa(dt[2], Vector{?Int})
+        @test isa(dt[1], Vector{Union{Int, Null}}) && isa(dt[2], Vector{Union{Int, Null}})
     end
 end

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -1,7 +1,6 @@
 module TestDataTable
     using Base.Test
-    using DataTables, Compat
-    import Compat.String
+    using DataTables, Nulls
 
     #
     # Equality
@@ -13,44 +12,43 @@ module TestDataTable
     @test !isequal(DataTable(a=[1, 2, 3], b=[4, 5, 6]), DataTable(a=[1, 2, 3], c=[4, 5, 6]))
     @test !isequal(DataTable(a=[1, 2, 3], b=[4, 5, 6]), DataTable(b=[4, 5, 6], a=[1, 2, 3]))
     @test !isequal(DataTable(a=[1, 2, 2], b=[4, 5, 6]), DataTable(a=[1, 2, 3], b=[4, 5, 6]))
-    @test isequal(DataTable(a=Nullable{Int}[1, 2, Nullable()], b=[4, 5, 6]),
-                  DataTable(a=Nullable{Int}[1, 2, Nullable()], b=[4, 5, 6]))
+    @test isequal(DataTable(a=[1, 2, null], b=[4, 5, 6]),
+                  DataTable(a=[1, 2, null], b=[4, 5, 6]))
 
-    # FIXME: equality operators won't work until JuliaStats/NullableArrays#84 is merged
-    #@test get(DataTable(a=[1, 2, 3], b=[4, 5, 6]) == DataTable(a=[1, 2, 3], b=[4, 5, 6]))
-    #@test get(DataTable(a=[1, 2], b=[4, 5]) != DataTable(a=[1, 2, 3], b=[4, 5, 6]))
-    #@test get(DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(a=[1, 2, 3]))
-    #@test get(DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(a=[1, 2, 3], c=[4, 5, 6]))
-    #@test get(DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(b=[4, 5, 6], a=[1, 2, 3]))
-    #@test get(DataTable(a=[1, 2, 2], b=[4, 5, 6]) != DataTable(a=[1, 2, 3], b=[4, 5, 6]))
-    #@test get(DataTable(a=Nullable{Int}[1, 3, Nullable()], b=[4, 5, 6]) !=
-    #          DataTable(a=Nullable{Int}[1, 2, Nullable()], b=[4, 5, 6]))
-    #@test isnull(DataTable(a=Nullable{Int}[1, 2, Nullable()], b=[4, 5, 6]) ==
-    #             DataTable(a=Nullable{Int}[1, 2, Nullable()], b=[4, 5, 6]))
-    #@test isnull(DataTable(a=Nullable{Int}[1, 2, Nullable()], b=[4, 5, 6]) ==
-    #             DataTable(a=Nullable{Int}[1, 2, 3], b=[4, 5, 6]))
+    @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) == DataTable(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataTable(a=[1, 2], b=[4, 5]) != DataTable(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(a=[1, 2, 3])
+    @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(a=[1, 2, 3], c=[4, 5, 6])
+    @test DataTable(a=[1, 2, 3], b=[4, 5, 6]) != DataTable(b=[4, 5, 6], a=[1, 2, 3])
+    @test DataTable(a=[1, 2, 2], b=[4, 5, 6]) != DataTable(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataTable(a=[1, 3, null], b=[4, 5, 6]) !=
+             DataTable(a=[1, 2, null], b=[4, 5, 6])
+    @test DataTable(a=[1, 2, null], b=[4, 5, 6]) ==
+                DataTable(a=[1, 2, null], b=[4, 5, 6])
+    @test DataTable(a=[1, 2, null], b=[4, 5, 6]) !=
+                DataTable(a=[1, 2, 3], b=[4, 5, 6])
 
     #
     # Copying
     #
 
-    dt = DataTable(a = NullableArray([2, 3]),
-                   b = NullableArray([DataTable(c = 1), DataTable(d = 2)]))
+    dt = DataTable(a = [2, 3],
+                   b = [DataTable(c = 1), DataTable(d = 2)])
     dtc = copy(dt)
     dtdc = deepcopy(dt)
 
     dt[1, :a] = 4
-    get(dt[1, :b])[:e] = 5
+    dt[1, :b][:e] = 5
     names!(dt, [:f, :g])
 
     @test names(dtc) == [:a, :b]
     @test names(dtdc) == [:a, :b]
 
-    @test get(dtc[1, :a]) === 4
-    @test get(dtdc[1, :a]) === 2
+    @test dtc[1, :a] === 4
+    @test dtdc[1, :a] === 2
 
-    @test names(get(dtc[1, :b])) == [:c, :e]
-    @test names(get(dtdc[1, :b])) == [:c]
+    @test names(dtc[1, :b]) == [:c, :e]
+    @test names(dtdc[1, :b]) == [:c]
 
     #
 
@@ -69,18 +67,18 @@ module TestDataTable
     @test_throws ErrorException x0[:d] = 1:3
 
     # Insert single value
-    x[:d] = Nullable(3)
-    @test isequal(x[:d], NullableArray([3, 3, 3]))
+    x[:d] = 3
+    @test isequal(x[:d], [3, 3, 3])
 
     x0[:d] = 3
     @test x0[:d] == Int[]
 
     # similar / nulls
-    dt = DataTable(a = NullableArray([1]),
-                   b = NullableArray(["b"]),
+    dt = DataTable(a = ?[1],
+                   b = ?["b"],
                    c = NullableCategoricalArray([3.3]))
-    nulldt = DataTable(a = NullableArray{Int}(2),
-                       b = NullableArray{String}(2),
+    nulldt = DataTable(a = nulls(Int, 2),
+                       b = nulls(String, 2),
                        c = NullableCategoricalArray{Float64}(2))
     @test isequal(nulldt, similar(dt, 2))
 
@@ -97,13 +95,13 @@ module TestDataTable
     @test isempty(dt.columns)
     @test isempty(dt)
 
-    dt = DataTable(a=NullableArray([1, 2]), b=NullableArray([3., 4.]))
+    dt = DataTable(a=(?Int)[1, 2], b=(?Float64)[3., 4.])
     @test_throws BoundsError insert!(dt, 5, ["a", "b"], :newcol)
     @test_throws ErrorException insert!(dt, 1, ["a"], :newcol)
     @test isequal(insert!(dt, 1, ["a", "b"], :newcol), dt)
     @test names(dt) == [:newcol, :a, :b]
-    @test isequal(dt[:a], NullableArray([1, 2]))
-    @test isequal(dt[:b], NullableArray([3., 4.]))
+    @test isequal(dt[:a], (?Int)[1, 2])
+    @test isequal(dt[:b], (?Float64)[3., 4.])
     @test isequal(dt[:newcol], ["a", "b"])
 
     dt = DataTable(a=[1, 2], b=[3., 4.])
@@ -112,48 +110,49 @@ module TestDataTable
     @test isequal(dt, DataTable(a=[1, 2], b=["a", "b"], c=[:c, :d]))
 
     #test_group("Empty DataTable constructors")
-    dt = DataTable(Nullable{Int}, 10, 3)
+    dt = DataTable(?Int, 10, 3)
     @test size(dt, 1) == 10
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == NullableVector{Int}
-    @test typeof(dt[:, 2]) == NullableVector{Int}
-    @test typeof(dt[:, 3]) == NullableVector{Int}
+    @test typeof(dt[:, 1]) == Vector{?Int}
+    @test typeof(dt[:, 2]) == Vector{?Int}
+    @test typeof(dt[:, 3]) == Vector{?Int}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
-    dt = DataTable([Nullable{Int}, Nullable{Float64}, Nullable{String}], 100)
+    dt = DataTable([?Int, ?Float64, ?String], 100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == NullableVector{Int}
-    @test typeof(dt[:, 2]) == NullableVector{Float64}
-    @test typeof(dt[:, 3]) == NullableVector{String}
+    @test typeof(dt[:, 1]) == Vector{?Int}
+    @test typeof(dt[:, 2]) == Vector{?Float64}
+    @test typeof(dt[:, 3]) == Vector{?String}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
-    dt = DataTable([Nullable{Int}, Nullable{Float64}, Nullable{String}],
+    dt = DataTable([?Int, ?Float64, ?String],
                    [:A, :B, :C], 100)
     @test size(dt, 1) == 100
     @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == NullableVector{Int}
-    @test typeof(dt[:, 2]) == NullableVector{Float64}
-    @test typeof(dt[:, 3]) == NullableVector{String}
+    @test typeof(dt[:, 1]) == Vector{?Int}
+    @test typeof(dt[:, 2]) == Vector{?Float64}
+    @test typeof(dt[:, 3]) == Vector{?String}
     @test all(isnull, dt[:, 1])
     @test all(isnull, dt[:, 2])
     @test all(isnull, dt[:, 3])
 
 
-    dt = DataTable([Nullable{Int}, Nullable{Float64}, Nullable{String}],
-                   [:A, :B, :C], [false, false, true],100)
-    @test size(dt, 1) == 100
-    @test size(dt, 2) == 3
-    @test typeof(dt[:, 1]) == NullableVector{Int}
-    @test typeof(dt[:, 2]) == NullableVector{Float64}
-    @test typeof(dt[:, 3]) == NullableCategoricalVector{Compat.UTF8String,UInt32}
-    @test all(isnull, dt[:, 1])
-    @test all(isnull, dt[:, 2])
-    @test all(isnull, dt[:, 3])
+    #FIXME: something in CategoricalArrays
+    # dt = DataTable([?Int, ?Float64, ?String],
+    #                [:A, :B, :C], [false, false, true],100)
+    # @test size(dt, 1) == 100
+    # @test size(dt, 2) == 3
+    # @test typeof(dt[:, 1]) == Vector{?Int}
+    # @test typeof(dt[:, 2]) == Vector{?Float64}
+    # @test typeof(dt[:, 3]) == NullableCategoricalVector{String,UInt32}
+    # @test all(isnull, dt[:, 1])
+    # @test all(isnull, dt[:, 2])
+    # @test all(isnull, dt[:, 3])
 
     dt = convert(DataTable, zeros(10, 5))
     @test size(dt, 1) == 10
@@ -170,8 +169,8 @@ module TestDataTable
     @test size(dt, 2) == 5
     @test typeof(dt[:, 1]) == Vector{Float64}
 
-    @test DataTable(NullableArray[[1,2,3],[2.5,4.5,6.5]], [:A, :B]) ==
-        DataTable(A = NullableArray([1,2,3]), B = NullableArray([2.5,4.5,6.5]))
+    @test DataTable([[1,2,3],[2.5,4.5,6.5]], [:A, :B]) ==
+        DataTable(A = [1,2,3], B = [2.5,4.5,6.5])
 
     # This assignment was missing before
     dt = DataTable(Column = [:A])
@@ -206,22 +205,22 @@ module TestDataTable
     @test_throws ArgumentError push!(dtb, ("coconut",22))
 
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
-    push!(dtb, @compat(Dict(:first=>3, :second=>"pear")))
+    push!(dtb, Dict(:first=>3, :second=>"pear"))
     @test isequal(dt, dtb)
 
     dt=DataTable( first=[1,2,3], second=["apple","orange","banana"] )
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
-    push!(dtb, @compat(Dict("first"=>3, "second"=>"banana")))
+    push!(dtb, Dict("first"=>3, "second"=>"banana"))
     @test isequal(dt, dtb)
 
     dt0= DataTable( first=[1,2], second=["apple","orange"] )
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dtb, @compat(Dict(:first=>true, :second=>false)))
+    @test_throws ArgumentError push!(dtb, Dict(:first=>true, :second=>false))
     @test isequal(dt0, dtb)
 
     dt0= DataTable( first=[1,2], second=["apple","orange"] )
     dtb= DataTable( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dtb, @compat(Dict("first"=>"chicken", "second"=>"stuff")))
+    @test_throws ArgumentError push!(dtb, Dict("first"=>"chicken", "second"=>"stuff"))
     @test isequal(dt0, dtb)
 
     # delete!
@@ -234,13 +233,13 @@ module TestDataTable
     delete!(d, [:a, :e, :c])
     @test names(d) == [:b, :d]
     delete!(d, :b)
-    @test isequal(d, dt[[:d]])
+    @test isequal(d, DataTable(d=4))
 
     d = copy(dt)
     delete!(d, [2, 5, 3])
     @test names(d) == [:a, :d]
     delete!(d, 2)
-    @test isequal(d, dt[[:a]])
+    @test isequal(d, DataTable(a=1))
 
     # deleterows!
     dt = DataTable(a=[1, 2], b=[3., 4.])
@@ -259,115 +258,117 @@ module TestDataTable
     @test deleterows!(dt, [2, 3]) === dt
     @test isequal(dt, DataTable(a=[1], b=[3.]))
 
-    dt = DataTable(a=NullableArray([1, 2]), b=NullableArray([3., 4.]))
+    dt = DataTable(a=[1, 2], b=[3., 4.])
     @test deleterows!(dt, 1) === dt
-    @test isequal(dt, DataTable(a=NullableArray([2]), b=NullableArray([4.])))
+    @test isequal(dt, DataTable(a=[2], b=[4.]))
 
-    dt = DataTable(a=NullableArray([1, 2]), b=NullableArray([3., 4.]))
+    dt = DataTable(a=[1, 2], b=[3., 4.])
     @test deleterows!(dt, 2) === dt
-    @test isequal(dt, DataTable(a=NullableArray([1]), b=NullableArray([3.])))
+    @test isequal(dt, DataTable(a=[1], b=[3.]))
 
-    dt = DataTable(a=NullableArray([1, 2, 3]), b=NullableArray([3., 4., 5.]))
+    dt = DataTable(a=[1, 2, 3], b=[3., 4., 5.])
     @test deleterows!(dt, 2:3) === dt
-    @test isequal(dt, DataTable(a=NullableArray([1]), b=NullableArray([3.])))
+    @test isequal(dt, DataTable(a=[1], b=[3.]))
 
-    dt = DataTable(a=NullableArray([1, 2, 3]), b=NullableArray([3., 4., 5.]))
+    dt = DataTable(a=[1, 2, 3], b=[3., 4., 5.])
     @test deleterows!(dt, [2, 3]) === dt
-    @test isequal(dt, DataTable(a=NullableArray([1]), b=NullableArray([3.])))
+    @test isequal(dt, DataTable(a=[1], b=[3.]))
 
     # describe
     #suppress output and test that describe() does not throw
     devnull = is_unix() ? "/dev/null" : "nul"
     open(devnull, "w") do f
-        @test nothing == describe(f, DataTable(a=[1, 2], b=Any["3", Nullable()]))
+        @test nothing == describe(f, DataTable(a=[1, 2], b=Any["3", null]))
         @test nothing ==
-              describe(f, DataTable(a=NullableArray([1, 2]),
-                                    b=NullableArray(Nullable{String}["3", Nullable()])))
+              describe(f, DataTable(a=[1, 2],
+                                    b=(?String)["3", null]))
         @test nothing ==
               describe(f, DataTable(a=CategoricalArray([1, 2]),
-                                    b=NullableCategoricalArray(Nullable{String}["3", Nullable()])))
+                                    b=NullableCategoricalArray((?String)["3", null])))
         @test nothing == describe(f, [1, 2, 3])
-        @test nothing == describe(f, NullableArray([1, 2, 3]))
+        @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, CategoricalArray([1, 2, 3]))
-        @test nothing == describe(f, Any["1", "2", Nullable()])
-        @test nothing == describe(f, NullableArray(Nullable{String}["1", "2", Nullable()]))
-        @test nothing == describe(f, NullableCategoricalArray(Nullable{String}["1", "2", Nullable()]))
+        @test nothing == describe(f, Any["1", "2", null])
+        @test nothing == describe(f, (?String)["1", "2", null])
+        @test nothing == describe(f, NullableCategoricalArray((?String)["1", "2", null]))
     end
 
     #Check the output of unstack
     dt = DataTable(Fish = NullableCategoricalArray(["Bob", "Bob", "Batman", "Batman"]),
-                   Key = Nullable{String}["Mass", "Color", "Mass", "Color"],
-                   Value = Nullable{String}["12 g", "Red", "18 g", "Grey"])
+                   Key = (?String)["Mass", "Color", "Mass", "Color"],
+                   Value = (?String)["12 g", "Red", "18 g", "Grey"])
     # Check that reordering levels does not confuse unstack
     levels!(dt[1], ["XXX", "Bob", "Batman"])
     #Unstack specifying a row column
-    dt2 = unstack(dt,:Fish, :Key, :Value)
+    dt2 = unstack(dt, :Fish, :Key, :Value)
     #Unstack without specifying a row column
-    dt3 = unstack(dt,:Key, :Value)
+    #FIXME
+    # dt3 = unstack(dt, :Key, :Value)
     #The expected output
-    dt4 = DataTable(Fish = Nullable{String}["XXX", "Bob", "Batman"],
-                    Color = Nullable{String}[Nullable(), "Red", "Grey"],
-                    Mass = Nullable{String}[Nullable(), "12 g", "18 g"])
+    dt4 = DataTable(Fish = (?String)["XXX", "Bob", "Batman"],
+                    Color = (?String)[null, "Red", "Grey"],
+                    Mass = (?String)[null, "12 g", "18 g"])
     @test isequal(dt2, dt4)
     @test typeof(dt2[:Fish]) <: NullableCategoricalArray{String,1,UInt32}
     # first column stays as CategoricalArray in dt3
-    @test isequal(dt3[:, 2:3], dt4[2:3, 2:3])
+    # @test isequal(dt3[:, 2:3], dt4[2:3, 2:3])
     #Make sure unstack works with NULLs at the start of the value column
-    dt[1,:Value] = Nullable()
-    dt2 = unstack(dt,:Fish, :Key, :Value)
+    dt[1,:Value] = null
+    dt2 = unstack(dt, :Fish, :Key, :Value)
     #This changes the expected result
-    dt4[2,:Mass] = Nullable()
+    dt4[2,:Mass] = null
     @test isequal(dt2, dt4)
 
     dt = DataTable(A = 1:10, B = 'A':'J')
     @test !(dt[:,:] === dt)
 
     @test append!(DataTable(A = 1:2, B = 1:2), DataTable(A = 3:4, B = 3:4)) == DataTable(A=1:4, B = 1:4)
-    dt = DataTable(A = NullableArray(1:3), B = NullableArray(4:6))
-    @test all(c -> isa(c, NullableArray), categorical!(deepcopy(dt)).columns)
-    @test all(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), [1,2]).columns)
-    @test all(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), [:A,:B]).columns)
-    @test find(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), [:A]).columns) == [1]
-    @test find(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), :A).columns) == [1]
-    @test find(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), [1]).columns) == [1]
-    @test find(c -> isa(c, NullableCategoricalArray), categorical!(deepcopy(dt), 1).columns) == [1]
+    dt = DataTable(A = 1:3, B = 4:6)
+    @test all(c -> isa(c, Vector), categorical!(deepcopy(dt)).columns)
+    @test all(c -> isa(c, CategoricalArray), categorical!(deepcopy(dt), [1,2]).columns)
+    @test all(c -> isa(c, CategoricalArray), categorical!(deepcopy(dt), [:A,:B]).columns)
+    @test find(c -> isa(c, CategoricalArray), categorical!(deepcopy(dt), [:A]).columns) == [1]
+    @test find(c -> isa(c, CategoricalArray), categorical!(deepcopy(dt), :A).columns) == [1]
+    @test find(c -> isa(c, CategoricalArray), categorical!(deepcopy(dt), [1]).columns) == [1]
+    @test find(c -> isa(c, CategoricalArray), categorical!(deepcopy(dt), 1).columns) == [1]
 
     @testset "unstack nullable promotion" begin
         dt = DataTable(Any[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
                        [:id, :variable, :value])
         udt = unstack(dt)
-        @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
-        @test udt == DataTable(Any[Nullable[1, 2], Nullable[1, 5], Nullable[2, 6],
-                                   Nullable[3, 7], Nullable[4, 8]], [:id, :a, :b, :c, :d])
-        @test all(typeof.(udt.columns) .== NullableVector{Int})
+        #FIXME
+        # @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
+        @test udt == DataTable(Any[[1, 2], [1, 5], [2, 6],
+                                   [3, 7], [4, 8]], [:id, :a, :b, :c, :d])
+        @test all(typeof.(udt.columns) .== Vector{?Int})
         dt = DataTable(Any[categorical(repeat(1:2, inner=4)),
                            categorical(repeat('a':'d', outer=2)), categorical(1:8)],
                        [:id, :variable, :value])
         udt = unstack(dt)
-        @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
-        @test udt == DataTable(Any[Nullable[1, 2], Nullable[1, 5], Nullable[2, 6],
-                                   Nullable[3, 7], Nullable[4, 8]], [:id, :a, :b, :c, :d])
+        # @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
+        @test udt == DataTable(Any[[1, 2], [1, 5], [2, 6],
+                                   [3, 7], [4, 8]], [:id, :a, :b, :c, :d])
         @test all(typeof.(udt.columns) .== NullableCategoricalVector{Int, UInt32})
     end
 
     @testset "duplicate entries in unstack warnings" begin
-        dt = DataTable(id=NullableArray([1, 2, 1, 2]), variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
+        dt = DataTable(id=(?Int)[1, 2, 1, 2], variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
         @static if VERSION >= v"0.6.0-dev.1980"
             @test_warn "Duplicate entries in unstack." unstack(dt, :id, :variable, :value)
-            @test_warn "Duplicate entries in unstack at row 3." unstack(dt, :variable, :value)
+            # @test_warn "Duplicate entries in unstack at row 3." unstack(dt, :variable, :value)
         end
         a = unstack(dt, :id, :variable, :value)
-        b = unstack(dt, :variable, :value)
-        @test a == b == DataTable(id = Nullable[1, 2], a = [5, Nullable()], b = [Nullable(), 6])
+        # b = unstack(dt, :variable, :value)
+        # @test a == b == DataTable(id = Nullable[1, 2], a = [5, null], b = [null, 6])
 
-        dt = DataTable(id=NullableArray(1:2), variable=["a", "b"], value=3:4)
+        dt = DataTable(id=1:2, variable=["a", "b"], value=3:4)
         @static if VERSION >= v"0.6.0-dev.1980"
             @test_nowarn unstack(dt, :id, :variable, :value)
-            @test_nowarn unstack(dt, :variable, :value)
+            # @test_nowarn unstack(dt, :variable, :value)
         end
         a = unstack(dt, :id, :variable, :value)
-        b = unstack(dt, :variable, :value)
-        @test a == b == DataTable(id = Nullable[1, 2], a = [3, Nullable()], b = [Nullable(), 4])
+        # b = unstack(dt, :variable, :value)
+        # @test a == b == DataTable(id = Nullable[1, 2], a = [3, null], b = [null, 4])
     end
 
     @testset "rename" begin
@@ -403,16 +404,16 @@ module TestDataTable
                                       3: Char C
                                   """
         dt = DataTable(A = 1:12, B = repeat('A':'C', inner=4))
-        @test DataTables.without(dt, 1) == DataTable(B = repeat('A':'C', inner=4))
+        # @test DataTables.without(dt, 1) == DataTable(B = repeat('A':'C', inner=4))
     end
 
     @testset "column conversions" begin
         dt = DataTable(Any[collect(1:10), collect(1:10)])
-        @test !isa(dt[1], NullableArray)
+        @test !isa(dt[1], Vector{?Int})
         nullable!(dt, 1)
-        @test isa(dt[1], NullableArray)
-        @test !isa(dt[2], NullableArray)
+        @test isa(dt[1], Vector{?Int})
+        @test !isa(dt[2], Vector{?Int})
         nullable!(dt, [1,2])
-        @test isa(dt[1], NullableArray) && isa(dt[2], NullableArray)
+        @test isa(dt[1], Vector{?Int}) && isa(dt[2], Vector{?Int})
     end
 end

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -310,7 +310,7 @@ module TestDataTable
     @test dt2 == dt4
     @test typeof(dt2[:Fish]) <: NullableCategoricalArray{String,1,UInt32}
     # first column stays as CategoricalArray in dt3
-    # @test isequal(dt3[:, 2:3], dt4[2:3, 2:3])
+    # @test dt3[:, 2:3] == dt4[2:3, 2:3]
     #Make sure unstack works with NULLs at the start of the value column
     dt[1,:Value] = null
     dt2 = unstack(dt, :Fish, :Key, :Value)

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -335,8 +335,7 @@ module TestDataTable
         dt = DataTable(Any[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
                        [:id, :variable, :value])
         udt = unstack(dt)
-        #FIXME
-        # @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
+        @test udt == unstack(dt, :variable, :value) == unstack(dt, :id, :variable, :value)
         @test udt == DataTable(Any[[1, 2], [1, 5], [2, 6],
                                    [3, 7], [4, 8]], [:id, :a, :b, :c, :d])
         @test all(typeof.(udt.columns) .== Vector{?Int})
@@ -354,20 +353,20 @@ module TestDataTable
         dt = DataTable(id=(?Int)[1, 2, 1, 2], variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
         @static if VERSION >= v"0.6.0-dev.1980"
             @test_warn "Duplicate entries in unstack." unstack(dt, :id, :variable, :value)
-            # @test_warn "Duplicate entries in unstack at row 3." unstack(dt, :variable, :value)
+            @test_warn "Duplicate entries in unstack at row 3." unstack(dt, :variable, :value)
         end
         a = unstack(dt, :id, :variable, :value)
-        # b = unstack(dt, :variable, :value)
-        # @test a == b == DataTable(id = Nullable[1, 2], a = [5, null], b = [null, 6])
+        b = unstack(dt, :variable, :value)
+        @test a == b == DataTable(id = [1, 2], a = [5, null], b = [null, 6])
 
         dt = DataTable(id=1:2, variable=["a", "b"], value=3:4)
         @static if VERSION >= v"0.6.0-dev.1980"
             @test_nowarn unstack(dt, :id, :variable, :value)
-            # @test_nowarn unstack(dt, :variable, :value)
+            @test_nowarn unstack(dt, :variable, :value)
         end
         a = unstack(dt, :id, :variable, :value)
-        # b = unstack(dt, :variable, :value)
-        # @test a == b == DataTable(id = Nullable[1, 2], a = [3, null], b = [null, 4])
+        b = unstack(dt, :variable, :value)
+        @test a == b == DataTable(id = [1, 2], a = [3, null], b = [null, 4])
     end
 
     @testset "rename" begin

--- a/test/datatable.jl
+++ b/test/datatable.jl
@@ -1,6 +1,5 @@
 module TestDataTable
-    using Base.Test
-    using DataTables, Nulls
+    using Base.Test, DataTables, Nulls
 
     #
     # Equality

--- a/test/datatablerow.jl
+++ b/test/datatablerow.jl
@@ -1,15 +1,11 @@
 module TestDataTableRow
-    using Base.Test
-    using DataTables, Compat
+    using Base.Test, DataTables, Nulls
 
-    dt = DataTable(a=NullableArray([1,   2,   3,   1,   2,   2 ]),
-                   b=NullableArray(Nullable{Float64}[2.0, Nullable(),
-                                                     1.2, 2.0,
-                                                     Nullable(), Nullable()]),
-                   c=NullableArray(Nullable{String}["A", "B", "C", "A", "B", Nullable()]),
-                   d=NullableCategoricalArray(Nullable{Symbol}[:A,  Nullable(),  :C,  :A,
-                                                           Nullable(),  :C]))
-    dt2 = DataTable(a = NullableArray([1, 2, 3]))
+    dt = DataTable(a=[1,   2,   3,   1,   2,   2 ],
+                   b=(?Float64)[2.0, null, 1.2, 2.0, null, null],
+                   c=(?String)["A", "B", "C", "A", "B", null],
+                   d=NullableCategoricalArray((?Symbol)[:A,  null,  :C,  :A, null,  :C]))
+    dt2 = DataTable(a = [1, 2, 3])
 
     #
     # Equality
@@ -22,9 +18,9 @@ module TestDataTableRow
     @test !isequal(DataTableRow(dt, 2), DataTableRow(dt, 6))
 
     # isless()
-    dt4 = DataTable(a=NullableArray([1, 1, 2, 2, 2, 2, Nullable(), Nullable()]),
-                    b=NullableArray([2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0]),
-                    c=NullableArray([:B, Nullable(), :A, :C, :D, :D, :A, :A]))
+    dt4 = DataTable(a=[1, 1, 2, 2, 2, 2, null, null],
+                    b=[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
+                    c=[:B, null, :A, :C, :D, :D, :A, :A])
     @test isless(DataTableRow(dt4, 1), DataTableRow(dt4, 2))
     @test !isless(DataTableRow(dt4, 2), DataTableRow(dt4, 1))
     @test !isless(DataTableRow(dt4, 1), DataTableRow(dt4, 1))

--- a/test/datatablerow.jl
+++ b/test/datatablerow.jl
@@ -2,45 +2,45 @@ module TestDataTableRow
     using Base.Test, DataTables, Nulls
 
     dt = DataTable(a=[1,   2,   3,   1,   2,   2 ],
-                   b=(?Float64)[2.0, null, 1.2, 2.0, null, null],
-                   c=(?String)["A", "B", "C", "A", "B", null],
-                   d=NullableCategoricalArray((?Symbol)[:A,  null,  :C,  :A, null,  :C]))
+                   b=[2.0, null, 1.2, 2.0, null, null],
+                   c=["A", "B", "C", "A", "B", null],
+                   d=NullableCategoricalArray([:A,  null,  :C,  :A, null,  :C]))
     dt2 = DataTable(a = [1, 2, 3])
 
     #
     # Equality
     #
-    @test_throws ArgumentError isequal(DataTableRow(dt, 1), DataTableRow(dt2, 1))
-    @test !isequal(DataTableRow(dt, 1), DataTableRow(dt, 2))
-    @test !isequal(DataTableRow(dt, 1), DataTableRow(dt, 3))
-    @test isequal(DataTableRow(dt, 1), DataTableRow(dt, 4))
-    @test isequal(DataTableRow(dt, 2), DataTableRow(dt, 5))
-    @test !isequal(DataTableRow(dt, 2), DataTableRow(dt, 6))
+    @test_throws ArgumentError DataTableRow(dt, 1) == DataTableRow(dt2, 1)
+    @test DataTableRow(dt, 1) != DataTableRow(dt, 2)
+    @test DataTableRow(dt, 1) != DataTableRow(dt, 3)
+    @test DataTableRow(dt, 1) == DataTableRow(dt, 4)
+    @test DataTableRow(dt, 2) == DataTableRow(dt, 5)
+    @test DataTableRow(dt, 2) != DataTableRow(dt, 6)
 
     # isless()
     dt4 = DataTable(a=[1, 1, 2, 2, 2, 2, null, null],
                     b=[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
                     c=[:B, null, :A, :C, :D, :D, :A, :A])
-    @test isless(DataTableRow(dt4, 1), DataTableRow(dt4, 2))
-    @test !isless(DataTableRow(dt4, 2), DataTableRow(dt4, 1))
-    @test !isless(DataTableRow(dt4, 1), DataTableRow(dt4, 1))
-    @test isless(DataTableRow(dt4, 1), DataTableRow(dt4, 3))
-    @test !isless(DataTableRow(dt4, 3), DataTableRow(dt4, 1))
-    @test isless(DataTableRow(dt4, 3), DataTableRow(dt4, 4))
-    @test !isless(DataTableRow(dt4, 4), DataTableRow(dt4, 3))
-    @test isless(DataTableRow(dt4, 4), DataTableRow(dt4, 5))
-    @test !isless(DataTableRow(dt4, 5), DataTableRow(dt4, 4))
-    @test !isless(DataTableRow(dt4, 6), DataTableRow(dt4, 5))
-    @test !isless(DataTableRow(dt4, 5), DataTableRow(dt4, 6))
-    @test isless(DataTableRow(dt4, 7), DataTableRow(dt4, 8))
-    @test !isless(DataTableRow(dt4, 8), DataTableRow(dt4, 7))
+    @test DataTableRow(dt4, 1) < DataTableRow(dt4, 2)
+    @test !(DataTableRow(dt4, 2) < DataTableRow(dt4, 1))
+    @test !(DataTableRow(dt4, 1) < DataTableRow(dt4, 1))
+    @test DataTableRow(dt4, 1) < DataTableRow(dt4, 3)
+    @test !(DataTableRow(dt4, 3) < DataTableRow(dt4, 1))
+    @test DataTableRow(dt4, 3) < DataTableRow(dt4, 4)
+    @test !(DataTableRow(dt4, 4) < DataTableRow(dt4, 3))
+    @test DataTableRow(dt4, 4) < DataTableRow(dt4, 5)
+    @test !(DataTableRow(dt4, 5) < DataTableRow(dt4, 4))
+    @test !(DataTableRow(dt4, 6) < DataTableRow(dt4, 5))
+    @test !(DataTableRow(dt4, 5) < DataTableRow(dt4, 6))
+    @test DataTableRow(dt4, 7) < DataTableRow(dt4, 8)
+    @test !(DataTableRow(dt4, 8) < DataTableRow(dt4, 7))
 
     # hashing
-    @test !isequal(hash(DataTableRow(dt, 1)), hash(DataTableRow(dt, 2)))
-    @test !isequal(hash(DataTableRow(dt, 1)), hash(DataTableRow(dt, 3)))
-    @test isequal(hash(DataTableRow(dt, 1)), hash(DataTableRow(dt, 4)))
-    @test isequal(hash(DataTableRow(dt, 2)), hash(DataTableRow(dt, 5)))
-    @test !isequal(hash(DataTableRow(dt, 2)), hash(DataTableRow(dt, 6)))
+    @test hash(DataTableRow(dt, 1)) != hash(DataTableRow(dt, 2))
+    @test hash(DataTableRow(dt, 1)) != hash(DataTableRow(dt, 3))
+    @test hash(DataTableRow(dt, 1)) == hash(DataTableRow(dt, 4))
+    @test hash(DataTableRow(dt, 2)) == hash(DataTableRow(dt, 5))
+    @test hash(DataTableRow(dt, 2)) != hash(DataTableRow(dt, 6))
 
 
     # check that hashrows() function generates the same hashes as DataTableRow
@@ -48,7 +48,7 @@ module TestDataTableRow
     @test dt_rowhashes == [hash(dr) for dr in eachrow(dt)]
 
     # test incompatible frames
-    @test_throws UndefVarError isequal(DataTableRow(dt, 1), DataTableRow(dt3, 1))
+    @test_throws UndefVarError DataTableRow(dt, 1) == DataTableRow(dt3, 1)
 
     # test RowGroupDict
     N = 20

--- a/test/datatablerow.jl
+++ b/test/datatablerow.jl
@@ -1,10 +1,10 @@
 module TestDataTableRow
     using Base.Test, DataTables
 
-    dt = DataTable(a=[1,   2,   3,   1,   2,   2 ],
+    dt = DataTable(a=Union{Int, Null}[1, 2, 3, 1, 2, 2],
                    b=[2.0, null, 1.2, 2.0, null, null],
                    c=["A", "B", "C", "A", "B", null],
-                   d=CategoricalArray([:A,  null,  :C,  :A, null,  :C]))
+                   d=CategoricalArray([:A, null, :C, :A, null, :C]))
     dt2 = DataTable(a = [1, 2, 3])
 
     #
@@ -19,21 +19,21 @@ module TestDataTableRow
 
     # isless()
     dt4 = DataTable(a=[1, 1, 2, 2, 2, 2, null, null],
-                    b=[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
+                    b=Union{Float64, Null}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
                     c=[:B, null, :A, :C, :D, :D, :A, :A])
     @test DataTableRow(dt4, 1) < DataTableRow(dt4, 2)
-    @test !(DataTableRow(dt4, 2) < DataTableRow(dt4, 1))
-    @test !(DataTableRow(dt4, 1) < DataTableRow(dt4, 1))
+    @test DataTableRow(dt4, 2) > DataTableRow(dt4, 1)
+    @test DataTableRow(dt4, 1) == DataTableRow(dt4, 1)
     @test DataTableRow(dt4, 1) < DataTableRow(dt4, 3)
-    @test !(DataTableRow(dt4, 3) < DataTableRow(dt4, 1))
+    @test DataTableRow(dt4, 3) > DataTableRow(dt4, 1)
     @test DataTableRow(dt4, 3) < DataTableRow(dt4, 4)
-    @test !(DataTableRow(dt4, 4) < DataTableRow(dt4, 3))
+    @test DataTableRow(dt4, 4) > DataTableRow(dt4, 3)
     @test DataTableRow(dt4, 4) < DataTableRow(dt4, 5)
-    @test !(DataTableRow(dt4, 5) < DataTableRow(dt4, 4))
-    @test !(DataTableRow(dt4, 6) < DataTableRow(dt4, 5))
-    @test !(DataTableRow(dt4, 5) < DataTableRow(dt4, 6))
+    @test DataTableRow(dt4, 5) > DataTableRow(dt4, 4)
+    @test DataTableRow(dt4, 6) == DataTableRow(dt4, 5)
+    @test DataTableRow(dt4, 5) == DataTableRow(dt4, 6)
     @test DataTableRow(dt4, 7) < DataTableRow(dt4, 8)
-    @test !(DataTableRow(dt4, 8) < DataTableRow(dt4, 7))
+    @test DataTableRow(dt4, 8) > DataTableRow(dt4, 7)
 
     # hashing
     @test hash(DataTableRow(dt, 1)) != hash(DataTableRow(dt, 2))

--- a/test/datatablerow.jl
+++ b/test/datatablerow.jl
@@ -1,10 +1,10 @@
 module TestDataTableRow
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dt = DataTable(a=[1,   2,   3,   1,   2,   2 ],
                    b=[2.0, null, 1.2, 2.0, null, null],
                    c=["A", "B", "C", "A", "B", null],
-                   d=NullableCategoricalArray([:A,  null,  :C,  :A, null,  :C]))
+                   d=CategoricalArray([:A,  null,  :C,  :A, null,  :C]))
     dt2 = DataTable(a = [1, 2, 3])
 
     #

--- a/test/duplicates.jl
+++ b/test/duplicates.jl
@@ -1,5 +1,5 @@
 module TestDuplicates
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dt = DataTable(a = [1, 2, 3, 3, 4])
     udt = DataTable(a = [1, 2, 3, 4])
@@ -8,10 +8,10 @@ module TestDuplicates
     unique!(dt)
     @test dt == udt
 
-    pdt = DataTable(a = NullableCategoricalArray(["a", "a", null, null, "b", null, "a", null]),
-                    b = NullableCategoricalArray(["a", "b", null, null, "b", "a", "a", "a"]))
-    updt = DataTable(a = NullableCategoricalArray(["a", "a", null, "b", null]),
-                     b = NullableCategoricalArray(["a", "b", null, "b", "a"]))
+    pdt = DataTable(a = CategoricalArray(["a", "a", null, null, "b", null, "a", null]),
+                    b = CategoricalArray(["a", "b", null, null, "b", "a", "a", "a"]))
+    updt = DataTable(a = CategoricalArray(["a", "a", null, "b", null]),
+                     b = CategoricalArray(["a", "b", null, "b", "a"]))
     @test nonunique(pdt) == [false, false, false, true, false, false, true, true]
     @test nonunique(updt) == falses(5)
     @test updt == unique(pdt)

--- a/test/duplicates.jl
+++ b/test/duplicates.jl
@@ -1,6 +1,5 @@
 module TestDuplicates
-    using Base.Test
-    using DataTables
+    using Base.Test, DataTables, Nulls
 
     dt = DataTable(a = [1, 2, 3, 3, 4])
     udt = DataTable(a = [1, 2, 3, 4])
@@ -9,12 +8,12 @@ module TestDuplicates
     unique!(dt)
     @test isequal(dt, udt)
 
-    pdt = DataTable(a = NullableCategoricalArray(Nullable{String}["a", "a", Nullable(),
-                                             Nullable(), "b", Nullable(), "a", Nullable()]),
-                    b = NullableCategoricalArray(Nullable{String}["a", "b", Nullable(),
-                                                              Nullable(), "b", "a", "a", "a"]))
-    updt = DataTable(a = NullableCategoricalArray(Nullable{String}["a", "a", Nullable(), "b", Nullable()]),
-                     b = NullableCategoricalArray(Nullable{String}["a", "b", Nullable(), "b", "a"]))
+    pdt = DataTable(a = NullableCategoricalArray((?String)["a", "a", null,
+                                             null, "b", null, "a", null]),
+                    b = NullableCategoricalArray((?String)["a", "b", null,
+                                                              null, "b", "a", "a", "a"]))
+    updt = DataTable(a = NullableCategoricalArray((?String)["a", "a", null, "b", null]),
+                     b = NullableCategoricalArray((?String)["a", "b", null, "b", "a"]))
     @test isequal(nonunique(pdt), [false, false, false, true, false, false, true, true])
     @test isequal(nonunique(updt), falses(5) )
     @test isequal(updt, unique(pdt))

--- a/test/duplicates.jl
+++ b/test/duplicates.jl
@@ -3,22 +3,20 @@ module TestDuplicates
 
     dt = DataTable(a = [1, 2, 3, 3, 4])
     udt = DataTable(a = [1, 2, 3, 4])
-    @test isequal(nonunique(dt), [false, false, false, true, false])
-    @test isequal(udt, unique(dt))
+    @test nonunique(dt) == [false, false, false, true, false]
+    @test udt == unique(dt)
     unique!(dt)
-    @test isequal(dt, udt)
+    @test dt == udt
 
-    pdt = DataTable(a = NullableCategoricalArray((?String)["a", "a", null,
-                                             null, "b", null, "a", null]),
-                    b = NullableCategoricalArray((?String)["a", "b", null,
-                                                              null, "b", "a", "a", "a"]))
-    updt = DataTable(a = NullableCategoricalArray((?String)["a", "a", null, "b", null]),
-                     b = NullableCategoricalArray((?String)["a", "b", null, "b", "a"]))
-    @test isequal(nonunique(pdt), [false, false, false, true, false, false, true, true])
-    @test isequal(nonunique(updt), falses(5) )
-    @test isequal(updt, unique(pdt))
+    pdt = DataTable(a = NullableCategoricalArray(["a", "a", null, null, "b", null, "a", null]),
+                    b = NullableCategoricalArray(["a", "b", null, null, "b", "a", "a", "a"]))
+    updt = DataTable(a = NullableCategoricalArray(["a", "a", null, "b", null]),
+                     b = NullableCategoricalArray(["a", "b", null, "b", "a"]))
+    @test nonunique(pdt) == [false, false, false, true, false, false, true, true]
+    @test nonunique(updt) == falses(5)
+    @test updt == unique(pdt)
     unique!(pdt)
-    @test isequal(pdt, updt)
+    @test pdt == updt
 
     @testset "missing" begin
         dt = DataTable(A = 1:12, B = repeat('A':'C', inner=4))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2,9 +2,9 @@ module TestGrouping
     using Base.Test, DataTables
 
     srand(1)
-    dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
-                   b = repeat([2, 1], outer=[4]),
-                   c = randn(8))
+    dt = DataTable(a = repeat(Union{Int, Null}[1, 2, 3, 4], outer=[2]),
+                   b = repeat(Union{Int, Null}[2, 1], outer=[4]),
+                   c = Vector{Union{Float64, Null}}(randn(8)))
     #dt[6, :a] = null
     #dt[7, :b] = null
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -15,7 +15,7 @@ module TestGrouping
             answer = [20, 12, -0.4283098098931877]
             @test isa(cw, Vector{Real})
             @test size(cw) == (ncol(dt),)
-            @test isequal(cw, answer)
+            @test cw == answer
 
             cw = colwise(sum, nullfree)
             answer = [55]
@@ -34,7 +34,7 @@ module TestGrouping
             answer = [20 12 -0.4283098098931877]
             @test isa(cw, Array{Real, 2})
             @test size(cw) == (length([sum]),ncol(dt))
-            @test isequal(cw, answer)
+            @test cw == answer
 
             cw = colwise([sum, minimum], nullfree)
             answer = reshape([55, 1], (2,1))
@@ -46,7 +46,7 @@ module TestGrouping
             answer = reshape([Vector{?Int}(1:10)], (1,1))
             @test isa(cw, Array{Vector{?Int},2})
             @test size(cw) == (1, ncol(nullfree))
-            @test isequal(cw, answer)
+            @test cw == answer
 
             @test_throws MethodError colwise(["Bob", :Susie], DataTable(A = 1:10, B = 11:20))
         end
@@ -61,7 +61,7 @@ module TestGrouping
             answer = Any[20 12 -0.4283098098931877; 8 8 8]
             @test isa(cw, Array{Real, 2})
             @test size(cw) == (length((sum, length)), ncol(dt))
-            @test isequal(cw, answer)
+            @test cw == answer
 
             cw = colwise((sum, length), nullfree)
             answer = reshape([55, 10], (2,1))
@@ -74,7 +74,7 @@ module TestGrouping
                              (2, ncol(nullfree)))
             @test typeof(cw) == Array{AbstractVector,2}
             @test size(cw) == (2, ncol(nullfree))
-            @test isequal(cw, answer)
+            @test cw == answer
 
             @test_throws MethodError colwise(("Bob", :Susie), DataTable(A = 1:10, B = 11:20))
         end
@@ -87,14 +87,14 @@ module TestGrouping
         @testset "::Function" begin
             cw = map(colwise(sum), (nullfree, dt))
             answer = ([55], Real[20, 12, -0.4283098098931877])
-            @test isequal(cw, answer)
+            @test cw == answer
 
             cw = map(colwise((sum, length)), (nullfree, dt))
             answer = (reshape([55, 10], (2,1)), Any[20 12 -0.4283098098931877; 8 8 8])
-            @test isequal(cw, answer)
+            @test cw == answer
 
             cw = map(colwise([sum, length]), (nullfree, dt))
-            @test isequal(cw, answer)
+            @test cw == answer
         end
     end
 
@@ -117,7 +117,7 @@ module TestGrouping
     gd = groupby(dt, cols)
     ga = map(f, gd)
 
-    @test isequal(bdt, combine(ga))
+    @test bdt == combine(ga)
 
     # groupby() with groups sorting
     gd = groupby(dt, cols, sort=true)
@@ -127,7 +127,7 @@ module TestGrouping
     g(dt) = DataTable(cmax1 = [c + 1 for c in dt[:cmax]])
     h(dt) = g(f(dt))
 
-    @test isequal(combine(map(h, gd)), combine(map(g, ga)))
+    @test combine(map(h, gd)) == combine(map(g, ga))
 
     # testing pool overflow
     dt2 = DataTable(v1 = categorical(collect(1:1000)), v2 = categorical(fill(1, 1000)))
@@ -146,29 +146,29 @@ module TestGrouping
 
     dt2 = by(e->1, DataTable(x=Int64[]), :x)
     @test size(dt2) == (0,2)
-    @test isequal(sum(dt2[:x]), 0)
+    @test sum(dt2[:x]) == 0
 
     # Check that reordering levels does not confuse groupby
     dt = DataTable(Key1 = CategoricalArray(["A", "A", "B", "B"]),
                    Key2 = CategoricalArray(["A", "B", "A", "B"]),
                    Value = 1:4)
     gd = groupby(dt, :Key1)
-    @test isequal(gd[1], DataTable(Key1=["A", "A"], Key2=["A", "B"], Value=1:2))
-    @test isequal(gd[2], DataTable(Key1=["B", "B"], Key2=["A", "B"], Value=3:4))
+    @test gd[1] == DataTable(Key1=["A", "A"], Key2=["A", "B"], Value=1:2)
+    @test gd[2] == DataTable(Key1=["B", "B"], Key2=["A", "B"], Value=3:4)
     gd = groupby(dt, [:Key1, :Key2])
-    @test isequal(gd[1], DataTable(Key1="A", Key2="A", Value=1))
-    @test isequal(gd[2], DataTable(Key1="A", Key2="B", Value=2))
-    @test isequal(gd[3], DataTable(Key1="B", Key2="A", Value=3))
-    @test isequal(gd[4], DataTable(Key1="B", Key2="B", Value=4))
+    @test gd[1] == DataTable(Key1="A", Key2="A", Value=1)
+    @test gd[2] == DataTable(Key1="A", Key2="B", Value=2)
+    @test gd[3] == DataTable(Key1="B", Key2="A", Value=3)
+    @test gd[4] == DataTable(Key1="B", Key2="B", Value=4)
     # Reorder levels, add unused level
     levels!(dt[:Key1], ["Z", "B", "A"])
     levels!(dt[:Key2], ["Z", "B", "A"])
     gd = groupby(dt, :Key1)
-    @test isequal(gd[1], DataTable(Key1=["A", "A"], Key2=["A", "B"], Value=1:2))
-    @test isequal(gd[2], DataTable(Key1=["B", "B"], Key2=["A", "B"], Value=3:4))
+    @test gd[1] == DataTable(Key1=["A", "A"], Key2=["A", "B"], Value=1:2)
+    @test gd[2] == DataTable(Key1=["B", "B"], Key2=["A", "B"], Value=3:4)
     gd = groupby(dt, [:Key1, :Key2])
-    @test isequal(gd[1], DataTable(Key1="A", Key2="A", Value=1))
-    @test isequal(gd[2], DataTable(Key1="A", Key2="B", Value=2))
-    @test isequal(gd[3], DataTable(Key1="B", Key2="A", Value=3))
-    @test isequal(gd[4], DataTable(Key1="B", Key2="B", Value=4))
+    @test gd[1] == DataTable(Key1="A", Key2="A", Value=1)
+    @test gd[2] == DataTable(Key1="A", Key2="B", Value=2)
+    @test gd[3] == DataTable(Key1="B", Key2="A", Value=3)
+    @test gd[4] == DataTable(Key1="B", Key2="B", Value=4)
 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1,12 +1,12 @@
 module TestGrouping
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     srand(1)
     dt = DataTable(a = repeat([1, 2, 3, 4], outer=[2]),
                    b = repeat([2, 1], outer=[4]),
                    c = randn(8))
-    #dt[6, :a] = Nullable()
-    #dt[7, :b] = Nullable()
+    #dt[6, :a] = null
+    #dt[7, :b] = null
 
     nullfree = DataTable(Any[collect(1:10)], [:x1])
     @testset "colwise" begin
@@ -42,9 +42,9 @@ module TestGrouping
             @test size(cw) == (length([sum, minimum]), ncol(nullfree))
             @test cw == answer
 
-            cw = colwise([Vector{?Int}], nullfree)
-            answer = reshape([Vector{?Int}(1:10)], (1,1))
-            @test isa(cw, Array{Vector{?Int},2})
+            cw = colwise([Vector{Union{Int, Null}}], nullfree)
+            answer = reshape([Vector{Union{Int, Null}}(1:10)], (1,1))
+            @test isa(cw, Array{Vector{Union{Int, Null}},2})
             @test size(cw) == (1, ncol(nullfree))
             @test cw == answer
 
@@ -69,8 +69,8 @@ module TestGrouping
             @test size(cw) == (length((sum, length)), ncol(nullfree))
             @test cw == answer
 
-            cw = colwise((CategoricalArray, Vector{?Int}), nullfree)
-            answer = reshape([CategoricalArray(1:10), Vector{?Int}(1:10)],
+            cw = colwise((CategoricalArray, Vector{Union{Int, Null}}), nullfree)
+            answer = reshape([CategoricalArray(1:10), Vector{Union{Int, Null}}(1:10)],
                              (2, ncol(nullfree)))
             @test typeof(cw) == Array{AbstractVector,2}
             @test size(cw) == (2, ncol(nullfree))

--- a/test/index.jl
+++ b/test/index.jl
@@ -15,11 +15,10 @@ inds = Any[1,
            1:1,
            1.0:1.0,
            [:A],
-           ?[true],
-           ?[1],
-           ?[1.0],
-           ?[:A],
-           ?[:A]]
+           (?Bool)[true],
+           (?Int)[1],
+           (?Float64)[1.0],
+           (?Symbol)[:A]]
 
 for ind in inds
     if ind == :A || ndims(ind) == 0

--- a/test/index.jl
+++ b/test/index.jl
@@ -22,8 +22,8 @@ inds = Any[1,
            ?[:A]]
 
 for ind in inds
-    if isequal(ind, :A) || ndims(ind) == 0
-        @test isequal(i[ind], 1)
+    if ind == :A || ndims(ind) == 0
+        @test i[ind] == 1
     else
         @test (i[ind] == [1])
     end

--- a/test/index.jl
+++ b/test/index.jl
@@ -1,6 +1,5 @@
 module TestIndex
-using Base.Test
-using DataTables, DataTables.Index, Compat
+using Base.Test, DataTables, Nulls, DataTables.Index
 
 i = Index()
 push!(i, :A)
@@ -16,11 +15,11 @@ inds = Any[1,
            1:1,
            1.0:1.0,
            [:A],
-           NullableArray([true]),
-           NullableArray([1]),
-           NullableArray([1.0]),
-           NullableArray([:A]),
-           NullableArray([:A])]
+           ?[true],
+           ?[1],
+           ?[1.0],
+           ?[:A],
+           ?[:A]]
 
 for ind in inds
     if isequal(ind, :A) || ndims(ind) == 0
@@ -34,7 +33,7 @@ end
 @test names!(i, [:a,:a], allow_duplicates=true) == Index([:a,:a_1])
 @test_throws ArgumentError names!(i, [:a,:a])
 @test names!(i, [:a,:b]) == Index([:a,:b])
-@test rename(i, @compat(Dict(:a=>:A, :b=>:B))) == Index([:A,:B])
+@test rename(i, Dict(:a=>:A, :b=>:B)) == Index([:A,:B])
 @test rename(i, :a, :A) == Index([:A,:b])
 @test rename(i, :a, :a) == Index([:a,:b])
 @test rename(i, [:a], [:A]) == Index([:A,:b])

--- a/test/index.jl
+++ b/test/index.jl
@@ -1,5 +1,5 @@
 module TestIndex
-using Base.Test, DataTables, Nulls, DataTables.Index
+using Base.Test, DataTables, DataTables.Index
 
 i = Index()
 push!(i, :A)
@@ -15,10 +15,10 @@ inds = Any[1,
            1:1,
            1.0:1.0,
            [:A],
-           (?Bool)[true],
-           (?Int)[1],
-           (?Float64)[1.0],
-           (?Symbol)[:A]]
+           Union{Bool, Null}[true],
+           Union{Int, Null}[1],
+           Union{Float64, Null}[1.0],
+           Union{Symbol, Null}[:A]]
 
 for ind in inds
     if ind == :A || ndims(ind) == 0

--- a/test/io.jl
+++ b/test/io.jl
@@ -59,6 +59,7 @@ module TestIO
 >>>>>>> Get PR 66 passing tests on Julia 0.7
 
     # DataStreams
+    # FIXME Update CSV to work with new DataStreams API
     # using CSV
     #
     # dt = CSV.read(joinpath(dirname(@__FILE__), "data/iris.csv"), DataTable)

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,5 +1,5 @@
 module TestIO
-    using Base.Test, DataTables, Nulls, CategoricalArrays
+    using Base.Test, DataTables, CategoricalArrays
     using LaTeXStrings
 
     # Test LaTeX export
@@ -41,11 +41,22 @@ module TestIO
                    B = 'a':'c',
                    C = ["A", "B", "C"],
                    D = CategoricalArray('a':'c'),
-                   E = NullableCategoricalArray(["A", "B", "C"]),
-                   E = Vector{?Int}(1:3),
-                   F = nulls(3),
-                   G = fill(null, 3))
+                   E = CategoricalArray(["A", "B", null]),
+                   F = Vector{Union{Int, Null}}(1:3),
+                   G = nulls(3),
+                   H = fill(null, 3))
 
+<<<<<<< HEAD
+=======
+    DRT = CategoricalArrays.DefaultRefType
+    @test sprint(printtable, dt) ==
+        """
+        "A","B","C","D","E","F","G","H"
+        1,"a","A","CategoricalArrays.CategoricalValue{Char,$DRT} 'a'","CategoricalArrays.CategoricalValue{String,$DRT} "A"","1",null,null
+        2,"b","B","CategoricalArrays.CategoricalValue{Char,$DRT} 'b'","CategoricalArrays.CategoricalValue{String,$DRT} "B"","2",null,null
+        3,"c","C","CategoricalArrays.CategoricalValue{Char,$DRT} 'c'",null,"3",null,null
+        """
+>>>>>>> Get PR 66 passing tests on Julia 0.7
 
     # DataStreams
     # using CSV

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,16 +1,12 @@
 module TestIO
-    using Base.Test
-    using DataTables
+    using Base.Test, DataTables, Nulls, CategoricalArrays
     using LaTeXStrings
-    using NullableArrays
-    using CategoricalArrays
 
     # Test LaTeX export
     dt = DataTable(A = 1:4,
                    B = ["\$10.0", "M&F", "A~B", "\\alpha"],
                    C = [L"\alpha", L"\beta", L"\gamma", L"\sum_{i=1}^n \delta_i"],
-                   D = [1.0, 2.0, Nullable(), 3.0],
-                   E = NullableCategoricalArray(["a", Nullable(), "c", "d"])
+                   D = [1.0, 2.0, null, 3.0]
                    )
     str = """
         \\begin{tabular}{r|ccccc}
@@ -25,16 +21,11 @@ module TestIO
     @test reprmime(MIME("text/latex"), dt) == str
 
     #Test HTML output for IJulia and similar
-    dt = DataTable(Fish = ["Suzy", "Amir"], Mass = [1.5, Nullable()],
-                   E = NullableCategoricalArray(["a", Nullable()]))
+    dt = DataTable(Fish = ["Suzy", "Amir"], Mass = [1.5, null])
     io = IOBuffer()
     show(io, "text/html", dt)
     str = String(take!(io))
-    @test str ==
-        "<table class=\"data-frame\"><tr><th></th><th>Fish</th><th>Mass</th><th>E</th></tr>" *
-        "<tr><th>1</th><td>Suzy</td><td>1.5</td><td>a</td></tr>" *
-        "<tr><th>2</th><td>Amir</td><td>#NULL</td><td>#NULL</td></tr></table>"
-
+    @test str == "<table class=\"data-frame\"><tr><th></th><th>Fish</th><th>Mass</th></tr><tr><th>1</th><td>Suzy</td><td>1.5</td></tr><tr><th>2</th><td>Amir</td><td>null</td></tr></table>"
 
     # test limit attribute of IOContext is used
     dt = DataTable(a=collect(1:1000))
@@ -51,21 +42,14 @@ module TestIO
                    C = ["A", "B", "C"],
                    D = CategoricalArray('a':'c'),
                    E = NullableCategoricalArray(["A", "B", "C"]),
-                   F = NullableArray(1:3),
-                   G = NullableArray(fill(Nullable(), 3)),
-                   H = fill(Nullable(), 3))
-
-    @test sprint(printtable, dt) == """
-        \"A\",\"B\",\"C\",\"D\",\"E\",\"F\",\"G\",\"H\"
-        1,\"'a'\",\"A\",\"'a'\",\"A\",\"1\",NULL,NULL
-        2,\"'b'\",\"B\",\"'b'\",\"B\",\"2\",NULL,NULL
-        3,\"'c'\",\"C\",\"'c'\",\"C\",\"3\",NULL,NULL
-        """
+                   E = Vector{?Int}(1:3),
+                   F = nulls(3),
+                   G = fill(null, 3))
 
 
     # DataStreams
-    using CSV
-
-    dt = CSV.read(joinpath(dirname(@__FILE__), "data/iris.csv"), DataTable)
-    @test size(dt) == (150, 5)
+    # using CSV
+    #
+    # dt = CSV.read(joinpath(dirname(@__FILE__), "data/iris.csv"), DataTable)
+    # @test size(dt) == (150, 5)
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -6,7 +6,8 @@ module TestIO
     dt = DataTable(A = 1:4,
                    B = ["\$10.0", "M&F", "A~B", "\\alpha"],
                    C = [L"\alpha", L"\beta", L"\gamma", L"\sum_{i=1}^n \delta_i"],
-                   D = [1.0, 2.0, null, 3.0]
+                   D = [1.0, 2.0, null, 3.0],
+                   E = CategoricalArray(["a", null, "c", "d"])
                    )
     str = """
         \\begin{tabular}{r|ccccc}
@@ -46,17 +47,13 @@ module TestIO
                    G = nulls(3),
                    H = fill(null, 3))
 
-<<<<<<< HEAD
-=======
-    DRT = CategoricalArrays.DefaultRefType
     @test sprint(printtable, dt) ==
         """
         "A","B","C","D","E","F","G","H"
-        1,"a","A","CategoricalArrays.CategoricalValue{Char,$DRT} 'a'","CategoricalArrays.CategoricalValue{String,$DRT} "A"","1",null,null
-        2,"b","B","CategoricalArrays.CategoricalValue{Char,$DRT} 'b'","CategoricalArrays.CategoricalValue{String,$DRT} "B"","2",null,null
-        3,"c","C","CategoricalArrays.CategoricalValue{Char,$DRT} 'c'",null,"3",null,null
+        1,"'a'","A","'a'","A","1",null,null
+        2,"'b'","B","'b'","B","2",null,null
+        3,"'c'","C","'c'",null,"3",null,null
         """
->>>>>>> Get PR 66 passing tests on Julia 0.7
 
     # DataStreams
     # FIXME Update CSV to work with new DataStreams API

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -1,7 +1,7 @@
 module TestIteration
     using Base.Test, DataTables, Nulls
 
-    dv = (?Int)[1, 2, null]
+    dv = [1, 2, null]
     dm = [1 2; 3 4]
     dt = zeros(2, 2, 2)
 
@@ -9,7 +9,7 @@ module TestIteration
 
     for row in eachrow(dt)
         @test isa(row, DataTableRow)
-        @test isequal(row[:B]-row[:A], 1)
+        @test (row[:B] - row[:A]) == 1
 
         # issue #683 (https://github.com/JuliaStats/DataFrames.jl/pull/683)
         @test typeof(collect(row)) == Array{Tuple{Symbol, Any}, 1}
@@ -19,28 +19,28 @@ module TestIteration
         @test isa(col, Tuple{Symbol, AbstractVector})
     end
 
-    @test isequal(map(x -> minimum(convert(Array, x)), eachrow(dt)), Any[1,2])
-    @test isequal(map(minimum, eachcol(dt)), DataTable(A = (?Int)[1], B = (?Int)[2]))
+    @test map(x -> minimum(convert(Array, x)), eachrow(dt)) == Any[1,2]
+    @test map(minimum, eachcol(dt)) == DataTable(A = [1], B = [2])
 
     row = DataTableRow(dt, 1)
 
     row[:A] = 100
-    @test isequal(dt[1, :A], 100)
+    @test dt[1, :A] == 100
 
     row[1] = 101
-    @test isequal(dt[1, :A], 101)
+    @test dt[1, :A] == 101
 
     dt = DataTable(A = 1:4, B = ["M", "F", "F", "M"])
 
     s1 = view(dt, 1:3)
     s1[2,:A] = 4
-    @test isequal(dt[2, :A], 4)
-    @test isequal(view(s1, 1:2), view(dt, 1:2))
+    @test dt[2, :A] == 4
+    @test view(s1, 1:2) == view(dt, 1:2)
 
     s2 = view(dt, 1:2:3)
     s2[2, :B] = "M"
-    @test isequal(dt[3, :B], "M")
-    @test isequal(view(s2, 1:1:2), view(dt, [1,3]))
+    @test dt[3, :B] == "M"
+    @test view(s2, 1:1:2) == view(dt, [1,3])
 
     # @test_fail for x in dt; end # Raises an error
 end

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -2,8 +2,8 @@ module TestIteration
     using Base.Test, DataTables
 
     dv = [1, 2, null]
-    dm = [1 2; 3 4]
-    dt = zeros(2, 2, 2)
+    dm = Union{Int, Null}[1 2; 3 4]
+    dt = Array{Union{Int, Null}}(zeros(2, 2, 2))
 
     dt = DataTable(A = 1:2, B = 2:3)
 
@@ -30,7 +30,7 @@ module TestIteration
     row[1] = 101
     @test dt[1, :A] == 101
 
-    dt = DataTable(A = 1:4, B = ["M", "F", "F", "M"])
+    dt = DataTable(A = Vector{Union{Int, Null}}(1:4), B = Union{String, Null}["M", "F", "F", "M"])
 
     s1 = view(dt, 1:3)
     s1[2,:A] = 4

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -1,5 +1,5 @@
 module TestIteration
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dv = [1, 2, null]
     dm = [1 2; 3 4]

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -1,45 +1,45 @@
 module TestIteration
-    using Base.Test, DataTables, Compat
+    using Base.Test, DataTables, Nulls
 
-    dv = NullableArray(Nullable{Int}[1, 2, Nullable()])
-    dm = NullableArray([1 2; 3 4])
-    dt = NullableArray(zeros(2, 2, 2))
+    dv = (?Int)[1, 2, null]
+    dm = [1 2; 3 4]
+    dt = zeros(2, 2, 2)
 
-    dt = DataTable(A = NullableArray(1:2), B = NullableArray(2:3))
+    dt = DataTable(A = 1:2, B = 2:3)
 
     for row in eachrow(dt)
         @test isa(row, DataTableRow)
-        @test isequal(row[:B]-row[:A], Nullable(1))
+        @test isequal(row[:B]-row[:A], 1)
 
         # issue #683 (https://github.com/JuliaStats/DataFrames.jl/pull/683)
-        @test typeof(collect(row)) == @compat Array{Tuple{Symbol, Any}, 1}
+        @test typeof(collect(row)) == Array{Tuple{Symbol, Any}, 1}
     end
 
     for col in eachcol(dt)
-        @test isa(col, @compat Tuple{Symbol, NullableVector})
+        @test isa(col, Tuple{Symbol, AbstractVector})
     end
 
     @test isequal(map(x -> minimum(convert(Array, x)), eachrow(dt)), Any[1,2])
-    @test isequal(map(minimum, eachcol(dt)), DataTable(A = Nullable{Int}[1], B = Nullable{Int}[2]))
+    @test isequal(map(minimum, eachcol(dt)), DataTable(A = (?Int)[1], B = (?Int)[2]))
 
     row = DataTableRow(dt, 1)
 
     row[:A] = 100
-    @test isequal(dt[1, :A], Nullable(100))
+    @test isequal(dt[1, :A], 100)
 
     row[1] = 101
-    @test isequal(dt[1, :A], Nullable(101))
+    @test isequal(dt[1, :A], 101)
 
-    dt = DataTable(A = NullableArray(1:4), B = NullableArray(["M", "F", "F", "M"]))
+    dt = DataTable(A = 1:4, B = ["M", "F", "F", "M"])
 
     s1 = view(dt, 1:3)
     s1[2,:A] = 4
-    @test isequal(dt[2, :A], Nullable(4))
+    @test isequal(dt[2, :A], 4)
     @test isequal(view(s1, 1:2), view(dt, 1:2))
 
     s2 = view(dt, 1:2:3)
     s2[2, :B] = "M"
-    @test isequal(dt[3, :B], Nullable("M"))
+    @test isequal(dt[3, :B], "M")
     @test isequal(view(s2, 1:1:2), view(dt, [1,3]))
 
     # @test_fail for x in dt; end # Raises an error

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -5,7 +5,7 @@ module TestIteration
     dm = Union{Int, Null}[1 2; 3 4]
     dt = Array{Union{Int, Null}}(zeros(2, 2, 2))
 
-    dt = DataTable(A = 1:2, B = 2:3)
+    dt = DataTable(A = Vector{Union{Int, Null}}(1:2), B = Vector{Union{Int, Null}}(2:3))
 
     for row in eachrow(dt)
         @test isa(row, DataTableRow)

--- a/test/join.jl
+++ b/test/join.jl
@@ -25,13 +25,13 @@ module TestJoin
     semi = unique(inner[:, [:ID, :Name]])
     anti = left[Bool[isnull(x) for x in left[:Job]], [:ID, :Name]]
 
-    @test isequal(join(name, job, on = :ID), inner)
-    @test isequal(join(name, job, on = :ID, kind = :inner), inner)
-    @test isequal(join(name, job, on = :ID, kind = :outer), outer)
-    @test isequal(join(name, job, on = :ID, kind = :left), left)
-    @test isequal(join(name, job, on = :ID, kind = :right), right)
-    @test isequal(join(name, job, on = :ID, kind = :semi), semi)
-    @test isequal(join(name, job, on = :ID, kind = :anti), anti)
+    @test join(name, job, on = :ID) == inner
+    @test join(name, job, on = :ID, kind = :inner) == inner
+    @test join(name, job, on = :ID, kind = :outer) == outer
+    @test join(name, job, on = :ID, kind = :left) == left
+    @test join(name, job, on = :ID, kind = :right) == right
+    @test join(name, job, on = :ID, kind = :semi) == semi
+    @test join(name, job, on = :ID, kind = :anti) == anti
     @test_throws ArgumentError join(name, job)
     @test_throws ArgumentError join(name, job, on=:ID, kind=:other)
 
@@ -40,13 +40,13 @@ module TestJoin
     nameid = name[on]
     jobid = job[on]
 
-    @test isequal(join(nameid, jobid, on = :ID), inner[on])
-    @test isequal(join(nameid, jobid, on = :ID, kind = :inner), inner[on])
-    @test isequal(join(nameid, jobid, on = :ID, kind = :outer), outer[on])
-    @test isequal(join(nameid, jobid, on = :ID, kind = :left), left[on])
-    @test isequal(join(nameid, jobid, on = :ID, kind = :right), right[on])
-    @test isequal(join(nameid, jobid, on = :ID, kind = :semi), semi[on])
-    @test isequal(join(nameid, jobid, on = :ID, kind = :anti), anti[on])
+    @test join(nameid, jobid, on = :ID) == inner[on]
+    @test join(nameid, jobid, on = :ID, kind = :inner) == inner[on]
+    @test join(nameid, jobid, on = :ID, kind = :outer) == outer[on]
+    @test join(nameid, jobid, on = :ID, kind = :left) == left[on]
+    @test join(nameid, jobid, on = :ID, kind = :right) == right[on]
+    @test join(nameid, jobid, on = :ID, kind = :semi) == semi[on]
+    @test join(nameid, jobid, on = :ID, kind = :anti) == anti[on]
 
     # Join on multiple keys
     dt1 = DataTable(A = 1, B = 2, C = 3)
@@ -62,7 +62,7 @@ module TestJoin
                       B = ['a', 'a', 'a', 'b', 'b', 'b'],
                       C = [3, 4, 5, 3, 4, 5])
 
-    @test isequal(join(dt1, dt2[[:C]], kind = :cross), cross)
+    @test join(dt1, dt2[[:C]], kind = :cross) == cross
 
     # Cross joins handle naming collisions
     @test size(join(dt1, dt1, kind = :cross)) == (4, 4)
@@ -72,27 +72,27 @@ module TestJoin
 
     # test empty inputs
     simple_dt(len::Int, col=:A) = (dt = DataTable(); dt[col]=collect(1:len); dt)
-    @test isequal(join(simple_dt(0), simple_dt(0), on = :A, kind = :left),  simple_dt(0))
-    @test isequal(join(simple_dt(2), simple_dt(0), on = :A, kind = :left),  simple_dt(2))
-    @test isequal(join(simple_dt(0), simple_dt(2), on = :A, kind = :left),  simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(0), on = :A, kind = :right), simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(2), on = :A, kind = :right), simple_dt(2))
-    @test isequal(join(simple_dt(2), simple_dt(0), on = :A, kind = :right), simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(0), on = :A, kind = :inner), simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(2), on = :A, kind = :inner), simple_dt(0))
-    @test isequal(join(simple_dt(2), simple_dt(0), on = :A, kind = :inner), simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(0), on = :A, kind = :outer), simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(2), on = :A, kind = :outer), simple_dt(2))
-    @test isequal(join(simple_dt(2), simple_dt(0), on = :A, kind = :outer), simple_dt(2))
-    @test isequal(join(simple_dt(0), simple_dt(0), on = :A, kind = :semi),  simple_dt(0))
-    @test isequal(join(simple_dt(2), simple_dt(0), on = :A, kind = :semi),  simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(2), on = :A, kind = :semi),  simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(0), on = :A, kind = :anti),  simple_dt(0))
-    @test isequal(join(simple_dt(2), simple_dt(0), on = :A, kind = :anti),  simple_dt(2))
-    @test isequal(join(simple_dt(0), simple_dt(2), on = :A, kind = :anti),  simple_dt(0))
-    @test isequal(join(simple_dt(0), simple_dt(0, :B), kind = :cross), DataTable(A=Int[], B=Int[]))
-    @test isequal(join(simple_dt(0), simple_dt(2, :B), kind = :cross), DataTable(A=Int[], B=Int[]))
-    @test isequal(join(simple_dt(2), simple_dt(0, :B), kind = :cross), DataTable(A=Int[], B=Int[]))
+    @test join(simple_dt(0), simple_dt(0), on = :A, kind = :left) == simple_dt(0)
+    @test join(simple_dt(2), simple_dt(0), on = :A, kind = :left) == simple_dt(2)
+    @test join(simple_dt(0), simple_dt(2), on = :A, kind = :left) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(0), on = :A, kind = :right) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(2), on = :A, kind = :right) == simple_dt(2)
+    @test join(simple_dt(2), simple_dt(0), on = :A, kind = :right) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(0), on = :A, kind = :inner) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(2), on = :A, kind = :inner) == simple_dt(0)
+    @test join(simple_dt(2), simple_dt(0), on = :A, kind = :inner) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(0), on = :A, kind = :outer) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(2), on = :A, kind = :outer) == simple_dt(2)
+    @test join(simple_dt(2), simple_dt(0), on = :A, kind = :outer) == simple_dt(2)
+    @test join(simple_dt(0), simple_dt(0), on = :A, kind = :semi) == simple_dt(0)
+    @test join(simple_dt(2), simple_dt(0), on = :A, kind = :semi) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(2), on = :A, kind = :semi) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(0), on = :A, kind = :anti) == simple_dt(0)
+    @test join(simple_dt(2), simple_dt(0), on = :A, kind = :anti) == simple_dt(2)
+    @test join(simple_dt(0), simple_dt(2), on = :A, kind = :anti) == simple_dt(0)
+    @test join(simple_dt(0), simple_dt(0, :B), kind = :cross) == DataTable(A=Int[], B=Int[])
+    @test join(simple_dt(0), simple_dt(2, :B), kind = :cross) == DataTable(A=Int[], B=Int[])
+    @test join(simple_dt(2), simple_dt(0, :B), kind = :cross) == DataTable(A=Int[], B=Int[])
 
     # issue #960
     dt1 = DataTable(A = 1:50,

--- a/test/join.jl
+++ b/test/join.jl
@@ -1,10 +1,10 @@
 module TestJoin
     using Base.Test, DataTables
 
-    name = DataTable(ID = [1, 2, 3],
-                     Name = ["John Doe", "Jane Doe", "Joe Blogs"])
-    job = DataTable(ID = [1, 2, 2, 4],
-                    Job = ["Lawyer", "Doctor", "Florist", "Farmer"])
+    name = DataTable(ID = Union{Int, Null}[1, 2, 3],
+                     Name = Union{String, Null}["John Doe", "Jane Doe", "Joe Blogs"])
+    job = DataTable(ID = Union{Int, Null}[1, 2, 2, 4],
+                    Job = Union{String, Null}["Lawyer", "Doctor", "Florist", "Farmer"])
 
     # Join on symbols or vectors of symbols
     join(name, job, on = :ID)
@@ -71,7 +71,9 @@ module TestJoin
     @test_throws ArgumentError join(dt1, dt2, on = :A, kind = :cross)
 
     # test empty inputs
-    simple_dt(len::Int, col=:A) = (dt = DataTable(); dt[col]=collect(1:len); dt)
+    simple_dt(len::Int, col=:A) = (dt = DataTable();
+                                   dt[col]=Vector{Union{Int, Null}}(1:len);
+                                   dt)
     @test join(simple_dt(0), simple_dt(0), on = :A, kind = :left) == simple_dt(0)
     @test join(simple_dt(2), simple_dt(0), on = :A, kind = :left) == simple_dt(2)
     @test join(simple_dt(0), simple_dt(2), on = :A, kind = :left) == simple_dt(0)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,5 +1,5 @@
 module TestShow
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dt = DataTable(A = 1:3, B = ["x", "y", "z"])
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,8 +1,6 @@
 module TestShow
-    using DataTables
-    using Compat
-    using Base.Test
-    import Compat.String
+    using Base.Test, DataTables, Nulls
+
     dt = DataTable(A = 1:3, B = ["x", "y", "z"])
 
     io = IOBuffer()
@@ -38,17 +36,16 @@ module TestShow
     show(io, A)
 
     #Test show output for REPL and similar
-    dt = DataTable(Fish = ["Suzy", "Amir"], Mass = [1.5, Nullable()],
-                   E = NullableCategoricalArray(["a", Nullable()]))
+    dt = DataTable(Fish = ["Suzy", "Amir"], Mass = [1.5, null])
     io = IOBuffer()
     show(io, dt)
     str = String(take!(io))
     @test str == """
-    2×3 DataTables.DataTable
-    │ Row │ Fish │ Mass  │ E     │
-    ├─────┼──────┼───────┼───────┤
-    │ 1   │ Suzy │ 1.5   │ a     │
-    │ 2   │ Amir │ #NULL │ #NULL │"""
+    2×2 DataTables.DataTable
+    │ Row │ Fish │ Mass │
+    ├─────┼──────┼──────┤
+    │ 1   │ Suzy │ 1.5  │
+    │ 2   │ Amir │ null │"""
 
     # Test computing width for Array{String} columns
     dt = DataTable(Any[["a"]], [:x])

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -10,11 +10,11 @@ module TestSort
 
     @test sortperm(d) == sortperm(dv1)
     @test sortperm(d[[:dv3, :dv1]]) == sortperm(dv3)
-    @test isequal(sort(d, cols=:dv1)[:dv3], sortperm(dv1))
-    @test isequal(sort(d, cols=:dv2)[:dv3], sortperm(dv1))
-    @test isequal(sort(d, cols=:cv1)[:dv3], sortperm(dv1))
-    @test isequal(sort(d, cols=[:dv1, :cv1])[:dv3], sortperm(dv1))
-    @test isequal(sort(d, cols=[:dv1, :dv3])[:dv3], sortperm(dv1))
+    @test sort(d, cols=:dv1)[:dv3] == sortperm(dv1)
+    @test sort(d, cols=:dv2)[:dv3] == sortperm(dv1)
+    @test sort(d, cols=:cv1)[:dv3] == sortperm(dv1)
+    @test sort(d, cols=[:dv1, :cv1])[:dv3] == sortperm(dv1)
+    @test sort(d, cols=[:dv1, :dv3])[:dv3] == sortperm(dv1)
 
     dt = DataTable(rank=rand(1:12, 1000),
                    chrom=rand(1:24, 1000),
@@ -32,13 +32,13 @@ module TestSort
     @test issorted(ds2, cols=(order(:rank, rev=true), :chrom, :pos))
     @test issorted(ds2, rev=(true, false, false))
 
-    @test isequal(ds2, ds)
+    @test ds2 == ds
 
     sort!(dt, cols=(:rank, :chrom, :pos), rev=(true, false, false))
     @test issorted(dt, cols=(order(:rank, rev=true), :chrom, :pos))
     @test issorted(dt, rev=(true, false, false))
 
-    @test isequal(dt, ds)
+    @test dt == ds
 
     # Check that columns that shares the same underlying array are only permuted once PR#1072
     dt = DataTable(a=[2,1])

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -1,21 +1,20 @@
 module TestSort
-    using Base.Test
-    using DataTables
+    using Base.Test, DataTables, Nulls
 
-    dv1 = NullableArray(Nullable{Int}[9, 1, 8, Nullable(), 3, 3, 7, Nullable()])
-    dv2 = NullableArray(Nullable{Int}[9, 1, 8, Nullable(), 3, 3, 7, Nullable()])
-    dv3 = NullableArray(1:8)
+    dv1 = [9, 1, 8, null, 3, 3, 7, null]
+    dv2 = [9, 1, 8, null, 3, 3, 7, null]
+    dv3 = Vector{?Int}(1:8)
     cv1 = NullableCategoricalArray(dv1, ordered=true)
 
     d = DataTable(dv1 = dv1, dv2 = dv2, dv3 = dv3, cv1 = cv1)
 
     @test sortperm(d) == sortperm(dv1)
     @test sortperm(d[[:dv3, :dv1]]) == sortperm(dv3)
-    @test isequal(sort(d, cols=:dv1)[:dv3], NullableArray(sortperm(dv1)))
-    @test isequal(sort(d, cols=:dv2)[:dv3], NullableArray(sortperm(dv1)))
-    @test isequal(sort(d, cols=:cv1)[:dv3], NullableArray(sortperm(dv1)))
-    @test isequal(sort(d, cols=[:dv1, :cv1])[:dv3], NullableArray(sortperm(dv1)))
-    @test isequal(sort(d, cols=[:dv1, :dv3])[:dv3], NullableArray(sortperm(dv1)))
+    @test isequal(sort(d, cols=:dv1)[:dv3], sortperm(dv1))
+    @test isequal(sort(d, cols=:dv2)[:dv3], sortperm(dv1))
+    @test isequal(sort(d, cols=:cv1)[:dv3], sortperm(dv1))
+    @test isequal(sort(d, cols=[:dv1, :cv1])[:dv3], sortperm(dv1))
+    @test isequal(sort(d, cols=[:dv1, :dv3])[:dv3], sortperm(dv1))
 
     dt = DataTable(rank=rand(1:12, 1000),
                    chrom=rand(1:24, 1000),

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -1,10 +1,10 @@
 module TestSort
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     dv1 = [9, 1, 8, null, 3, 3, 7, null]
     dv2 = [9, 1, 8, null, 3, 3, 7, null]
-    dv3 = Vector{?Int}(1:8)
-    cv1 = NullableCategoricalArray(dv1, ordered=true)
+    dv3 = Vector{Union{Int, Null}}(1:8)
+    cv1 = CategoricalArray(dv1, ordered=true)
 
     d = DataTable(dv1 = dv1, dv2 = dv2, dv3 = dv3, cv1 = cv1)
 

--- a/test/subdatatable.jl
+++ b/test/subdatatable.jl
@@ -1,6 +1,5 @@
 module TestSubDataTable
-    using Base.Test
-    using DataTables
+    using Base.Test, DataTables, Nulls
 
     @testset "view -- DataTable" begin
         dt = DataTable(x = 1:10, y = 1.0:10.0)
@@ -33,15 +32,11 @@ module TestSubDataTable
         @test view(dt, Integer[1, 2]) == head(dt, 2)
         @test view(dt, UInt[1, 2]) == head(dt, 2)
         @test view(dt, BigInt[1, 2]) == head(dt, 2)
-        @test view(dt, Nullable{Int}[1, 2]) == head(dt, 2)
-        @test view(dt, Nullable{Integer}[1, 2]) == head(dt, 2)
-        @test view(dt, Nullable{UInt}[1, 2]) == head(dt, 2)
-        @test view(dt, Nullable{BigInt}[1, 2]) == head(dt, 2)
-        @test view(dt, NullableArray([1, 2])) == head(dt, 2)
-        @test view(dt, NullableArray{Integer}([1, 2])) == head(dt, 2)
-        @test view(dt, NullableArray{UInt}([1, 2])) == head(dt, 2)
-        @test view(dt, NullableArray{BigInt}([1, 2])) == head(dt, 2)
-        @test_throws NullException view(dt, [Nullable(), 1])
+        @test view(dt, (?Int)[1, 2]) == head(dt, 2)
+        @test view(dt, (?Integer)[1, 2]) == head(dt, 2)
+        @test view(dt, (?UInt)[1, 2]) == head(dt, 2)
+        @test view(dt, (?BigInt)[1, 2]) == head(dt, 2)
+        @test_throws NullException view(dt, [null, 1])
     end
 
     @testset "view -- SubDataTable" begin
@@ -75,14 +70,10 @@ module TestSubDataTable
         @test view(dt, Integer[1, 2]) == head(dt, 2)
         @test view(dt, UInt[1, 2]) == head(dt, 2)
         @test view(dt, BigInt[1, 2]) == head(dt, 2)
-        @test view(dt, Nullable{Int}[1, 2]) == head(dt, 2)
-        @test view(dt, Nullable{Integer}[1, 2]) == head(dt, 2)
-        @test view(dt, Nullable{UInt}[1, 2]) == head(dt, 2)
-        @test view(dt, Nullable{BigInt}[1, 2]) == head(dt, 2)
-        @test view(dt, NullableArray([1, 2])) == head(dt, 2)
-        @test view(dt, NullableArray{Integer}([1, 2])) == head(dt, 2)
-        @test view(dt, NullableArray{UInt}([1, 2])) == head(dt, 2)
-        @test view(dt, NullableArray{BigInt}([1, 2])) == head(dt, 2)
-        @test_throws NullException view(dt, [Nullable(), 1])
+        @test view(dt, (?Int)[1, 2]) == head(dt, 2)
+        @test view(dt, (?Integer)[1, 2]) == head(dt, 2)
+        @test view(dt, (?UInt)[1, 2]) == head(dt, 2)
+        @test view(dt, (?BigInt)[1, 2]) == head(dt, 2)
+        @test_throws NullException view(dt, [null, 1])
     end
 end

--- a/test/subdatatable.jl
+++ b/test/subdatatable.jl
@@ -1,5 +1,5 @@
 module TestSubDataTable
-    using Base.Test, DataTables, Nulls
+    using Base.Test, DataTables
 
     @testset "view -- DataTable" begin
         dt = DataTable(x = 1:10, y = 1.0:10.0)
@@ -32,10 +32,10 @@ module TestSubDataTable
         @test view(dt, Integer[1, 2]) == head(dt, 2)
         @test view(dt, UInt[1, 2]) == head(dt, 2)
         @test view(dt, BigInt[1, 2]) == head(dt, 2)
-        @test view(dt, (?Int)[1, 2]) == head(dt, 2)
-        @test view(dt, (?Integer)[1, 2]) == head(dt, 2)
-        @test view(dt, (?UInt)[1, 2]) == head(dt, 2)
-        @test view(dt, (?BigInt)[1, 2]) == head(dt, 2)
+        @test view(dt, Union{Int, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{Integer, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{UInt, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{BigInt, Null}[1, 2]) == head(dt, 2)
         @test_throws NullException view(dt, [null, 1])
     end
 
@@ -70,10 +70,10 @@ module TestSubDataTable
         @test view(dt, Integer[1, 2]) == head(dt, 2)
         @test view(dt, UInt[1, 2]) == head(dt, 2)
         @test view(dt, BigInt[1, 2]) == head(dt, 2)
-        @test view(dt, (?Int)[1, 2]) == head(dt, 2)
-        @test view(dt, (?Integer)[1, 2]) == head(dt, 2)
-        @test view(dt, (?UInt)[1, 2]) == head(dt, 2)
-        @test view(dt, (?BigInt)[1, 2]) == head(dt, 2)
+        @test view(dt, Union{Int, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{Integer, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{UInt, Null}[1, 2]) == head(dt, 2)
+        @test view(dt, Union{BigInt, Null}[1, 2]) == head(dt, 2)
         @test_throws NullException view(dt, [null, 1])
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -61,7 +61,7 @@ module TestUtils
 
     @testset "describe" begin
         io = IOBuffer()
-        dt = DataTable(Any[collect(1:4), NullableArray(2:5),
+        dt = DataTable(Any[collect(1:4), Vector{?Int}(2:5),
                            CategoricalArray(3:6),
                            NullableCategoricalArray(4:7)],
                        [:arr, :nullarr, :cat, :nullcat])
@@ -77,34 +77,25 @@ module TestUtils
             3rd Quartile:   3.250000
             Maximum:        4.000000
             Length:         4
-            Type:           $Int
+            Type:           Int64
 
             nullarr
             Summary Stats:
-            Mean:           3.500000
-            Minimum:        2.000000
-            1st Quartile:   2.750000
-            Median:         3.500000
-            3rd Quartile:   4.250000
-            Maximum:        5.000000
             Length:         4
-            Type:           $Int
-            Number Missing: 0
-            % Missing:      0.000000
+            Type:           Union{Int64, Nulls.Null}
+            Number Unique:  4
 
             cat
             Summary Stats:
             Length:         4
-            Type:           CategoricalArrays.CategoricalValue{$Int,$(CategoricalArrays.DefaultRefType)}
+            Type:           CategoricalArrays.CategoricalValue{Int64,UInt32}
             Number Unique:  4
 
             nullcat
             Summary Stats:
             Length:         4
-            Type:           Nullable{CategoricalArrays.CategoricalValue{$Int,$(CategoricalArrays.DefaultRefType)}}
+            Type:           Union{CategoricalArrays.CategoricalValue{Int64,UInt32}, Nulls.Null}
             Number Unique:  4
-            Number Missing: 0
-            % Missing:      0.000000
 
             """
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -67,7 +67,8 @@ module TestUtils
                        [:arr, :nullarr, :cat, :nullcat])
         describe(io, dt)
         DRT = CategoricalArrays.DefaultRefType
-        @test String(take!(io)) ==
+        # Julia 0.7
+        nullfirst =
             """
             arr
             Summary Stats:
@@ -78,7 +79,7 @@ module TestUtils
             3rd Quartile:   3.250000
             Maximum:        4.000000
             Length:         4
-            Type:           Int64
+            Type:           $Int
 
             nullarr
             Summary Stats:
@@ -89,24 +90,68 @@ module TestUtils
             3rd Quartile:   4.250000
             Maximum:        5.000000
             Length:         4
-            Type:           Union{Nulls.Null, Int64}
+            Type:           Union{Nulls.Null, $Int}
             Number Missing: 0
             % Missing:      0.000000
 
             cat
             Summary Stats:
             Length:         4
-            Type:           CategoricalArrays.CategoricalValue{Int64,UInt32}
+            Type:           CategoricalArrays.CategoricalValue{$Int,$DRT}
             Number Unique:  4
 
             nullcat
             Summary Stats:
             Length:         4
-            Type:           Union{Nulls.Null, CategoricalArrays.CategoricalValue{Int64,UInt32}}
+            Type:           Union{Nulls.Null, CategoricalArrays.CategoricalValue{$Int,$DRT}}
             Number Unique:  4
             Number Missing: 0
             % Missing:      0.000000
 
             """
+        # Julia 0.6
+        nullsecond =
+            """
+            arr
+            Summary Stats:
+            Mean:           2.500000
+            Minimum:        1.000000
+            1st Quartile:   1.750000
+            Median:         2.500000
+            3rd Quartile:   3.250000
+            Maximum:        4.000000
+            Length:         4
+            Type:           $Int
+
+            nullarr
+            Summary Stats:
+            Mean:           3.500000
+            Minimum:        2.000000
+            1st Quartile:   2.750000
+            Median:         3.500000
+            3rd Quartile:   4.250000
+            Maximum:        5.000000
+            Length:         4
+            Type:           Union{$Int, Nulls.Null}
+            Number Missing: 0
+            % Missing:      0.000000
+
+            cat
+            Summary Stats:
+            Length:         4
+            Type:           CategoricalArrays.CategoricalValue{$Int,$DRT}
+            Number Unique:  4
+
+            nullcat
+            Summary Stats:
+            Length:         4
+            Type:           Union{CategoricalArrays.CategoricalValue{$Int,$DRT}, Nulls.Null}
+            Number Unique:  4
+            Number Missing: 0
+            % Missing:      0.000000
+
+            """
+            out = String(take!(io))
+            @test (out == nullfirst || out == nullsecond)
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,8 +1,5 @@
 module TestUtils
-    using Base.Test
-    using DataTables
-    using Compat
-    using StatsBase
+    using Base.Test, DataTables, Nulls, StatsBase
     import DataTables: identifier
 
     @test identifier("%_B*_\tC*") == :_B_C_
@@ -41,18 +38,18 @@ module TestUtils
 
     @test DataTables.countnull([1:3;]) == 0
 
-    data = NullableArray(rand(20))
+    data = Vector{?Float64}(rand(20))
     @test DataTables.countnull(data) == 0
-    data[sample(1:20, 11, replace=false)] = Nullable()
+    data[sample(1:20, 11, replace=false)] = null
     @test DataTables.countnull(data) == 11
-    data[1:end] = Nullable()
+    data[1:end] = null
     @test DataTables.countnull(data) == 20
 
-    pdata = NullableArray(sample(1:5, 20))
+    pdata = Vector{?Int}(sample(1:5, 20))
     @test DataTables.countnull(pdata) == 0
-    pdata[sample(1:20, 11, replace=false)] = Nullable()
+    pdata[sample(1:20, 11, replace=false)] = null
     @test DataTables.countnull(pdata) == 11
-    pdata[1:end] = Nullable()
+    pdata[1:end] = null
     @test DataTables.countnull(pdata) == 20
 
     funs = [mean, sum, var, x -> sum(x)]


### PR DESCRIPTION
See https://github.com/JuliaData/DataTables.jl/pull/66. I opened this to avoid force pushing onto the old PR so we could preserve that as a reference in case I did anything wrong in the rebase.

Still todo:
- [ ] update CSV.jl with new DataStreams API and uncomment basic CSV file reading test in test/io.jl
- [ ] tag versions for and update REQUIRE with minimums for
    - [x] v0.0.6 Nulls.jl https://github.com/JuliaLang/METADATA.jl/pull/10979
    - [ ] v0.2.0 CategoricalArrays
    - [ ] v0.2.0 DataStreams https://github.com/JuliaLang/METADATA.jl/pull/10969 & https://github.com/JuliaLang/METADATA.jl/pull/10915
    - [ ] v0.2.0 CSV
    - [x] v0.3.0 WeakRefStrings https://github.com/JuliaLang/METADATA.jl/pull/10880